### PR TITLE
Set up basic documentation generation flow

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Auto-generated
+docs/API.md

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,737 @@
+## Functions
+
+- [ClientApiProvider](#clientapiprovider)
+- [useClientApi](#useclientapi)
+- [baseQueryOptions](#basequeryoptions)
+- [deviceInfoQueryOptions](#deviceinfoqueryoptions)
+- [useOwnDeviceInfo](#useowndeviceinfo)
+- [getDocumentsQueryKey](#getdocumentsquerykey)
+- [getManyDocumentsQueryKey](#getmanydocumentsquerykey)
+- [getDocumentByDocIdQueryKey](#getdocumentbydocidquerykey)
+- [getDocumentByVersionIdQueryKey](#getdocumentbyversionidquerykey)
+- [documentsQueryOptions](#documentsqueryoptions)
+- [documentByDocumentIdQueryOptions](#documentbydocumentidqueryoptions)
+- [documentByVersionIdQueryOptions](#documentbyversionidqueryoptions)
+- [getProjectsQueryKey](#getprojectsquerykey)
+- [getProjectByIdQueryKey](#getprojectbyidquerykey)
+- [getProjectSettingsQueryKey](#getprojectsettingsquerykey)
+- [getProjectRoleQueryKey](#getprojectrolequerykey)
+- [getMembersQueryKey](#getmembersquerykey)
+- [getMemberByIdQueryKey](#getmemberbyidquerykey)
+- [getIconUrlQueryKey](#geticonurlquerykey)
+- [getDocumentCreatedByQueryKey](#getdocumentcreatedbyquerykey)
+- [getAttachmentUrlQueryKey](#getattachmenturlquerykey)
+- [projectsQueryOptions](#projectsqueryoptions)
+- [projectByIdQueryOptions](#projectbyidqueryoptions)
+- [projectSettingsQueryOptions](#projectsettingsqueryoptions)
+- [projectMembersQueryOptions](#projectmembersqueryoptions)
+- [projectMemberByIdQueryOptions](#projectmemberbyidqueryoptions)
+- [projectOwnRoleQueryOptions](#projectownrolequeryoptions)
+- [iconUrlQueryOptions](#iconurlqueryoptions)
+- [documentCreatedByQueryOptions](#documentcreatedbyqueryoptions)
+- [attachmentUrlQueryOptions](#attachmenturlqueryoptions)
+- [useProjectSettings](#useprojectsettings)
+- [useSingleProject](#usesingleproject)
+- [useManyProjects](#usemanyprojects)
+- [useSingleMember](#usesinglemember)
+- [useManyMembers](#usemanymembers)
+- [useIconUrl](#useiconurl)
+- [useAttachmentUrl](#useattachmenturl)
+- [useDocumentCreatedBy](#usedocumentcreatedby)
+- [useSingleDocByDocId](#usesingledocbydocid)
+- [useSingleDocByVersionId](#usesingledocbyversionid)
+- [useManyDocs](#usemanydocs)
+- [getMapsQueryKey](#getmapsquerykey)
+- [getStyleJsonUrlQueryKey](#getstylejsonurlquerykey)
+- [mapStyleJsonUrlQueryOptions](#mapstylejsonurlqueryoptions)
+- [useMapStyleUrl](#usemapstyleurl)
+- [getInvitesQueryKey](#getinvitesquerykey)
+- [getPendingInvitesQueryKey](#getpendinginvitesquerykey)
+- [pendingInvitesQueryOptions](#pendinginvitesqueryoptions)
+
+### ClientApiProvider
+
+Create a context provider that holds a CoMapeo API client instance.
+
+| Function | Type |
+| ---------- | ---------- |
+| `ClientApiProvider` | `({ children, clientApi, }: { children: ReactNode; clientApi: MapeoClientApi; }) => FunctionComponentElement<ProviderProps<MapeoClientApi or null>>` |
+
+Parameters:
+
+* `opts.children`: React children node
+* `opts.clientApi`: Client API instance
+
+
+### useClientApi
+
+Access a client API instance. If a ClientApiContext provider is not
+set up, it will throw an error.
+
+| Function | Type |
+| ---------- | ---------- |
+| `useClientApi` | `() => MapeoClientApi` |
+
+Examples:
+
+```tsx
+function ClientExample() {
+  return (
+    // Creation of clientApi omitted for brevity
+    <ClientApiContext.Provider clientApi={clientApi}>
+      <ComponentThatUsesClient />
+    </ClientApiContext.Provider>
+  )
+}
+
+function ComponentThatUsesClient() {
+  const clientApi = useClientApi()
+
+  // Rest omitted for brevity.
+}
+```
+
+
+### baseQueryOptions
+
+| Function | Type |
+| ---------- | ---------- |
+| `baseQueryOptions` | `() => { networkMode: "always"; retry: number; }` |
+
+### deviceInfoQueryOptions
+
+| Function | Type |
+| ---------- | ---------- |
+| `deviceInfoQueryOptions` | `({ clientApi, }: { clientApi: MapeoClientApi; }) => OmitKeyof<UseQueryOptions<{ deviceId: string; deviceType: "device_type_unspecified" or "mobile" or "tablet" or "desktop" or "selfHostedServer" or "UNRECOGNIZED"; } and Partial<...>, Error, { ...; } and Partial<...>, QueryKey>, "queryFn"> and { ...; } and { ...; }` |
+
+### useOwnDeviceInfo
+
+Retrieve info about the current device.
+
+| Function | Type |
+| ---------- | ---------- |
+| `useOwnDeviceInfo` | `() => { data: { deviceId: string; deviceType: "device_type_unspecified" or "mobile" or "tablet" or "desktop" or "selfHostedServer" or "UNRECOGNIZED"; } and Partial<DeviceInfoParam>; isRefetching: boolean; }` |
+
+Examples:
+
+```tsx
+function DeviceInfoExample() {
+  const { data, isRefetching } = useDeviceInfo()
+}
+```
+
+
+### getDocumentsQueryKey
+
+| Function | Type |
+| ---------- | ---------- |
+| `getDocumentsQueryKey` | `<D extends DocumentType>({ projectId, docType, }: { projectId: string; docType: D; }) => readonly ["@comapeo/react", "projects", string, D]` |
+
+### getManyDocumentsQueryKey
+
+| Function | Type |
+| ---------- | ---------- |
+| `getManyDocumentsQueryKey` | `<D extends DocumentType>({ projectId, docType, opts, }: { projectId: string; docType: D; opts?: Parameters<ClientApi<MapeoProject>[D]["getMany"]>[0] or undefined; }) => readonly [...]` |
+
+### getDocumentByDocIdQueryKey
+
+| Function | Type |
+| ---------- | ---------- |
+| `getDocumentByDocIdQueryKey` | `<D extends DocumentType>({ projectId, docType, docId, opts, }: { projectId: string; docType: D; docId: Parameters<ClientApi<MapeoProject>[D]["getByDocId"]>[0]; opts?: Parameters<ClientApi<MapeoProject>[D]["getByDocId"]>[1] or undefined; }) => readonly [...]` |
+
+### getDocumentByVersionIdQueryKey
+
+| Function | Type |
+| ---------- | ---------- |
+| `getDocumentByVersionIdQueryKey` | `<D extends DocumentType>({ projectId, docType, versionId, opts, }: { projectId: string; docType: D; versionId: Parameters<ClientApi<MapeoProject>[D]["getByVersionId"]>[0]; opts?: Parameters<ClientApi<...>[D]["getByVersionId"]>[1] or undefined; }) => readonly [...]` |
+
+### documentsQueryOptions
+
+| Function | Type |
+| ---------- | ---------- |
+| `documentsQueryOptions` | `<D extends DocumentType>({ projectApi, projectId, docType, opts, }: { projectApi: ClientApi<MapeoProject>; projectId: string; docType: D; opts?: Parameters<ClientApi<MapeoProject>[D]["getMany"]>[0] or undefined; }) => OmitKeyof<...> and ... 1 more ... and { ...; }` |
+
+### documentByDocumentIdQueryOptions
+
+| Function | Type |
+| ---------- | ---------- |
+| `documentByDocumentIdQueryOptions` | `<D extends DocumentType>({ projectApi, projectId, docType, docId, opts, }: { projectApi: ClientApi<MapeoProject>; projectId: string; docType: D; docId: Parameters<ClientApi<MapeoProject>[D]["getByDocId"]>[0]; opts?: Omit<...> or undefined; }) => OmitKeyof<...> and ... 1 more ... and { ...; }` |
+
+### documentByVersionIdQueryOptions
+
+| Function | Type |
+| ---------- | ---------- |
+| `documentByVersionIdQueryOptions` | `<D extends DocumentType>({ projectApi, projectId, docType, versionId, opts, }: { projectApi: ClientApi<MapeoProject>; projectId: string; docType: D; versionId: Parameters<ClientApi<MapeoProject>[D]["getByVersionId"]>[0]; opts?: Parameters<...>[1] or undefined; }) => OmitKeyof<...> and ... 1 more ... and { ...; }` |
+
+### getProjectsQueryKey
+
+| Function | Type |
+| ---------- | ---------- |
+| `getProjectsQueryKey` | `() => readonly ["@comapeo/react", "projects"]` |
+
+### getProjectByIdQueryKey
+
+| Function | Type |
+| ---------- | ---------- |
+| `getProjectByIdQueryKey` | `({ projectId }: { projectId: string; }) => readonly ["@comapeo/react", "projects", string]` |
+
+### getProjectSettingsQueryKey
+
+| Function | Type |
+| ---------- | ---------- |
+| `getProjectSettingsQueryKey` | `({ projectId, }: { projectId: string; }) => readonly ["@comapeo/react", "projects", string, "project_settings"]` |
+
+### getProjectRoleQueryKey
+
+| Function | Type |
+| ---------- | ---------- |
+| `getProjectRoleQueryKey` | `({ projectId }: { projectId: string; }) => readonly ["@comapeo/react", "projects", string, "role"]` |
+
+### getMembersQueryKey
+
+| Function | Type |
+| ---------- | ---------- |
+| `getMembersQueryKey` | `({ projectId }: { projectId: string; }) => readonly ["@comapeo/react", "projects", string, "members"]` |
+
+### getMemberByIdQueryKey
+
+| Function | Type |
+| ---------- | ---------- |
+| `getMemberByIdQueryKey` | `({ projectId, deviceId, }: { projectId: string; deviceId: string; }) => readonly ["@comapeo/react", "projects", string, "members", string]` |
+
+### getIconUrlQueryKey
+
+| Function | Type |
+| ---------- | ---------- |
+| `getIconUrlQueryKey` | `({ projectId, iconId, opts, }: { projectId: string; iconId: string; opts: BitmapOpts or SvgOpts; }) => readonly ["@comapeo/react", "projects", string, "icons", string, BitmapOpts or SvgOpts]` |
+
+### getDocumentCreatedByQueryKey
+
+| Function | Type |
+| ---------- | ---------- |
+| `getDocumentCreatedByQueryKey` | `({ projectId, originalVersionId, }: { projectId: string; originalVersionId: string; }) => readonly ["@comapeo/react", "projects", string, "document_created_by", string]` |
+
+### getAttachmentUrlQueryKey
+
+| Function | Type |
+| ---------- | ---------- |
+| `getAttachmentUrlQueryKey` | `({ projectId, blobId, }: { projectId: string; blobId: BlobId; }) => readonly ["@comapeo/react", "projects", string, "attachments", BlobId]` |
+
+### projectsQueryOptions
+
+| Function | Type |
+| ---------- | ---------- |
+| `projectsQueryOptions` | `({ clientApi, }: { clientApi: MapeoClientApi; }) => OmitKeyof<UseQueryOptions<(Pick<{ schemaName: "projectSettings"; name?: string or undefined; defaultPresets?: { point: string[]; area: string[]; vertex: string[]; line: string[]; relation: string[]; } or undefined; configMetadata?: { ...; } or undefined; }, "name"> and ...` |
+
+### projectByIdQueryOptions
+
+| Function | Type |
+| ---------- | ---------- |
+| `projectByIdQueryOptions` | `({ clientApi, projectId, }: { clientApi: MapeoClientApi; projectId: string; }) => OmitKeyof<UseQueryOptions<ClientApi<MapeoProject>, Error, ClientApi<MapeoProject>, QueryKey>, "queryFn"> and { ...; } and { ...; }` |
+
+### projectSettingsQueryOptions
+
+| Function | Type |
+| ---------- | ---------- |
+| `projectSettingsQueryOptions` | `({ projectApi, projectId, }: { projectApi: ClientApi<MapeoProject>; projectId: string; }) => OmitKeyof<UseQueryOptions<EditableProjectSettings, Error, EditableProjectSettings, QueryKey>, "queryFn"> and { ...; } and { ...; }` |
+
+### projectMembersQueryOptions
+
+| Function | Type |
+| ---------- | ---------- |
+| `projectMembersQueryOptions` | `({ projectApi, projectId, }: { projectApi: ClientApi<MapeoProject>; projectId: string; }) => OmitKeyof<UseQueryOptions<MemberInfo[], Error, MemberInfo[], QueryKey>, "queryFn"> and { ...; } and { ...; }` |
+
+### projectMemberByIdQueryOptions
+
+| Function | Type |
+| ---------- | ---------- |
+| `projectMemberByIdQueryOptions` | `({ projectApi, projectId, deviceId, }: { projectApi: ClientApi<MapeoProject>; projectId: string; deviceId: string; }) => OmitKeyof<UseQueryOptions<MemberInfo, Error, MemberInfo, QueryKey>, "queryFn"> and { ...; } and { ...; }` |
+
+### projectOwnRoleQueryOptions
+
+| Function | Type |
+| ---------- | ---------- |
+| `projectOwnRoleQueryOptions` | `({ projectApi, projectId, }: { projectApi: ClientApi<MapeoProject>; projectId: string; }) => OmitKeyof<UseQueryOptions<Role<"a12a6702b93bd7ff" or "f7c150f5a3a9a855" or "012fd2d431c0bf60" or "9e6d29263cba36c9" or "8ced989b1904606b" or "08e4251e36f6e7ed">, Error, Role<...>, QueryKey>, "queryFn"> and { ...; } and { ...; }` |
+
+### iconUrlQueryOptions
+
+| Function | Type |
+| ---------- | ---------- |
+| `iconUrlQueryOptions` | `({ projectApi, projectId, iconId, opts, }: { projectApi: ClientApi<MapeoProject>; projectId: string; iconId: string; opts: BitmapOpts or SvgOpts; }) => OmitKeyof<UseQueryOptions<string, Error, string, QueryKey>, "queryFn"> and { ...; } and { ...; }` |
+
+### documentCreatedByQueryOptions
+
+| Function | Type |
+| ---------- | ---------- |
+| `documentCreatedByQueryOptions` | `({ projectApi, projectId, originalVersionId, }: { projectApi: ClientApi<MapeoProject>; projectId: string; originalVersionId: string; }) => OmitKeyof<UseQueryOptions<string, Error, string, QueryKey>, "queryFn"> and { ...; } and { ...; }` |
+
+### attachmentUrlQueryOptions
+
+| Function | Type |
+| ---------- | ---------- |
+| `attachmentUrlQueryOptions` | `({ projectApi, projectId, blobId, }: { projectApi: ClientApi<MapeoProject>; projectId: string; blobId: BlobId; }) => OmitKeyof<UseQueryOptions<string, Error, string, QueryKey>, "queryFn"> and { ...; } and { ...; }` |
+
+### useProjectSettings
+
+Retrieve the project settings for a project.
+
+| Function | Type |
+| ---------- | ---------- |
+| `useProjectSettings` | `({ projectId }: { projectId: string; }) => { data: EditableProjectSettings; isRefetching: boolean; }` |
+
+Parameters:
+
+* `opts.projectId`: Project public ID
+
+
+Examples:
+
+```tsx
+function BasicExample() {
+  const { data, isRefetching } = useProjectSettings({ projectId: '...' })
+
+  console.log(data.name)
+}
+```
+
+
+### useSingleProject
+
+Retrieve a project API instance for a project.
+
+This is mostly used internally by the other hooks and should only be used if certain project APIs are not exposed via the hooks.
+
+| Function | Type |
+| ---------- | ---------- |
+| `useSingleProject` | `({ projectId }: { projectId: string; }) => { data: ClientApi<MapeoProject>; isRefetching: boolean; }` |
+
+Parameters:
+
+* `opts.projectId`: Project public ID
+
+
+Examples:
+
+```tsx
+function BasicExample() {
+  const { data, isRefetching } = useSingleProject({ projectId: '...' })
+}
+```
+
+
+### useManyProjects
+
+Retrieve project information for each project that exists.
+
+| Function | Type |
+| ---------- | ---------- |
+| `useManyProjects` | `() => { data: (Pick<{ schemaName: "projectSettings"; name?: string or undefined; defaultPresets?: { point: string[]; area: string[]; vertex: string[]; line: string[]; relation: string[]; } or undefined; configMetadata?: { ...; } or undefined; }, "name"> and { ...; })[]; isRefetching: boolean; }` |
+
+Examples:
+
+```tsx
+function BasicExample() {
+  const { data, isRefetching } = useManyProjects()
+
+  console.log(data.map(project => project.name))
+}
+```
+
+
+### useSingleMember
+
+Retrieve a single member of a project.
+
+| Function | Type |
+| ---------- | ---------- |
+| `useSingleMember` | `({ projectId, deviceId, }: { projectId: string; deviceId: string; }) => { data: MemberInfo; isRefetching: boolean; }` |
+
+Parameters:
+
+* `opts.projectId`: Project public ID
+* `opts.projectId`: Device ID of interest
+
+
+Examples:
+
+```tsx
+function BasicExample() {
+  const { data, isRefetching } = useSingleMember({ projectId: '...', deviceId: '...' })
+
+  console.log(data.role)
+}
+```
+
+
+### useManyMembers
+
+Retrieve all members of a project.
+
+| Function | Type |
+| ---------- | ---------- |
+| `useManyMembers` | `({ projectId }: { projectId: string; }) => { data: MemberInfo[]; isRefetching: boolean; }` |
+
+Parameters:
+
+* `opts.projectId`: Project public ID
+
+
+Examples:
+
+```tsx
+function BasicExample() {
+  const { data, isRefetching } = useManyMembers({ projectId: '...' })
+
+  console.log(data.role)
+}
+```
+
+
+### useIconUrl
+
+Retrieve a URL that points to icon resources served by the embedded HTTP server.
+
+_TODO: Explain bitmap opts vs svg opts_
+
+| Function | Type |
+| ---------- | ---------- |
+| `useIconUrl` | `({ projectId, iconId, opts, }: { projectId: string; iconId: string; opts: BitmapOpts or SvgOpts; }) => { data: string; isRefetching: boolean; }` |
+
+Parameters:
+
+* `opts.projectId`: Project public ID
+* `opts.iconId`: Icon ID of interest
+* `opts.opts`: Parameters related to the mime type of the icon of interest
+
+
+Examples:
+
+```tsx
+function PngExample() {
+  const { data, isRefetching } = useIconUrl({
+    projectId: '...',
+    iconId: '...',
+    opts: {
+      mimeType: 'image/png',
+      pixelDensity: 1,
+      size: 'medium'
+    }
+  })
+}
+```
+
+```tsx
+function SvgExample() {
+  const { data, isRefetching } = useIconUrl({
+    projectId: '...',
+    iconId: '...',
+    opts: {
+      mimeType: 'image/svg',
+      size: 'medium'
+    }
+  })
+}
+```
+
+
+### useAttachmentUrl
+
+Retrieve a URL that points to a desired blob resource.
+
+_TODO: Explain BlobId in more depth_
+
+| Function | Type |
+| ---------- | ---------- |
+| `useAttachmentUrl` | `({ projectId, blobId, }: { projectId: string; blobId: BlobId; }) => { data: string; isRefetching: boolean; }` |
+
+Parameters:
+
+* `opts.projectId`: Project public Id
+* `opts.blobId`: Blob ID of the desired resource
+
+
+Examples:
+
+```tsx
+function PhotoExample() {
+  const { data, isRefetching } = useAttachmentUrl({
+    projectId: '...',
+    blobId: {
+      type: 'photo',
+      variant: 'thumbnail',
+      name: '...',
+      driveId: '...',
+    }
+  })
+}
+```
+
+```tsx
+function AudioExample() {
+  const { data, isRefetching } = useAttachmentUrl({
+    projectId: '...',
+    blobId: {
+      type: 'audio',
+      variant: 'original',
+      name: '...',
+      driveId: '...',
+    }
+  })
+}
+```
+
+```tsx
+function VideoExample() {
+  const { data, isRefetching } = useAttachmentUrl({
+    projectId: '...',
+    blobId: {
+      type: 'video',
+      variant: 'original',
+      name: '...',
+      driveId: '...',
+    }
+  })
+}
+```
+
+
+### useDocumentCreatedBy
+
+Retrieve the device ID that created a document.
+
+| Function | Type |
+| ---------- | ---------- |
+| `useDocumentCreatedBy` | `({ projectId, originalVersionId, }: { projectId: string; originalVersionId: string; }) => { data: string; isRefetching: boolean; }` |
+
+Parameters:
+
+* `opts.projectId`: Project public ID
+* `opts.originalVersionId`: Version ID of document
+
+
+Examples:
+
+```tsx
+function BasicExample() {
+  const { data, isRefetching } = useDocumentCreatedBy({
+    projectId: '...',
+    originalVersionId: '...',
+  })
+}
+```
+
+
+### useSingleDocByDocId
+
+Retrieve a single document from the database based on the document's document ID.
+
+Triggers the closest error boundary if the document cannot be found
+
+| Function | Type |
+| ---------- | ---------- |
+| `useSingleDocByDocId` | `<D extends DocumentType>({ projectId, docType, docId, opts, }: { projectId: string; docType: D; docId: string; opts?: Omit<{ mustBeFound?: boolean or undefined; lang?: string or undefined; } or undefined, "mustBeFound"> or undefined; }) => { ...; }` |
+
+Parameters:
+
+* `opts.projectId`: Project public ID
+* `opts.docType`: Document type of interest
+* `opts.docId`: Document ID
+* `opts.opts.lang`: Language to translate the document into
+
+
+Examples:
+
+```tsx
+function SingleDocumentByDocIdExample() {
+  const { data, isRefetching } = useSingleDocByDocId({
+    projectId: '...',
+    docType: 'observation',
+    docId: '...',
+  })
+
+  console.log(data.schemaName) // logs 'observation'
+}
+```
+
+
+### useSingleDocByVersionId
+
+Retrieve a single document from the database based on the document's version ID.
+
+Triggers the closest error boundary if the document cannot be found.
+
+| Function | Type |
+| ---------- | ---------- |
+| `useSingleDocByVersionId` | `<D extends DocumentType>({ projectId, docType, versionId, opts, }: { projectId: string; docType: D; versionId: string; opts?: { lang?: string or undefined; } or undefined; }) => { data: { schemaName: "track"; locations: Position[]; ... 8 more ...; deleted: boolean; } or { ...; } or { ...; } or { ...; } or { ...; }; isRefe...` |
+
+Parameters:
+
+* `opts.projectId`: Project public ID
+* `opts.docType`: Document type of interest
+* `opts.versionId`: Document's version ID
+* `opts.opts.lang`: Language to translate the document into
+
+*
+
+
+Examples:
+
+```tsx
+function SingleDocumentByVersionIdExample() {
+  const { data, isRefetching } = useSingleDocByVersionId({
+    projectId: '...',
+    docType: 'observation',
+    docId: '...',
+  })
+
+  console.log(data.schemaName) // logs 'observation'
+}
+```
+
+
+### useManyDocs
+
+Retrieve all documents of a specific `docType`.
+
+| Function | Type |
+| ---------- | ---------- |
+| `useManyDocs` | `<D extends DocumentType>({ projectId, docType, opts, }: { projectId: string; docType: D; opts?: { includeDeleted?: boolean or undefined; lang?: string or undefined; } or undefined; }) => { data: ({ schemaName: "track"; locations: Position[]; ... 8 more ...; deleted: boolean; } and { ...; })[] or ({ ...; } and { ...; })[] or ...` |
+
+Parameters:
+
+* `opts.projectId`: Project public ID
+* `opts.docType`: Document type of interest
+* `opts.opts.includeDeleted`: Include documents that have been marked as deleted
+* `opts.opts.lang`: Language to translate the documents into
+
+
+Examples:
+
+```tsx
+function BasicExample() {
+  const { data, isRefetching } = useManyDocs({
+    projectId: '...',
+    docType: 'observations',
+  })
+}
+```
+
+```tsx
+function useAllObservations(opts) {
+  return useManyDocs({
+    ...opts,
+    docType: 'observations',
+  })
+}
+
+function useAllPresets(opts) {
+  return useManyDocs({
+    ...opts,
+    docType: 'presets',
+  })
+}
+```
+
+
+### getMapsQueryKey
+
+| Function | Type |
+| ---------- | ---------- |
+| `getMapsQueryKey` | `() => readonly ["@comapeo/react", "maps"]` |
+
+### getStyleJsonUrlQueryKey
+
+| Function | Type |
+| ---------- | ---------- |
+| `getStyleJsonUrlQueryKey` | `({ refreshToken, }: { refreshToken?: string or undefined; }) => readonly ["@comapeo/react", "maps", "stylejson_url", { readonly refreshToken: string or undefined; }]` |
+
+### mapStyleJsonUrlQueryOptions
+
+| Function | Type |
+| ---------- | ---------- |
+| `mapStyleJsonUrlQueryOptions` | `({ clientApi, refreshToken, }: { clientApi: MapeoClientApi; refreshToken?: string or undefined; }) => OmitKeyof<UseQueryOptions<string, Error, string, QueryKey>, "queryFn"> and { ...; } and { ...; }` |
+
+### useMapStyleUrl
+
+Get a URL that points to a StyleJSON resource served by the embedded HTTP server.
+
+If `opts.refreshToken` is specified, it will be appended to the returned URL as a search param. This is useful for forcing cache busting
+due to hidden internal details by consuming components (e.g. map component from MapLibre).
+
+| Function | Type |
+| ---------- | ---------- |
+| `useMapStyleUrl` | `({ refreshToken, }?: { refreshToken?: string or undefined; }) => { data: string; isRefetching: boolean; }` |
+
+Parameters:
+
+* `opts.refreshToken`: String to append to the returned value as a search param
+
+
+Examples:
+
+```tsx
+function ExampleWithoutRefreshToken() {
+  const { data, isRefetching } = useMapStyleUrl()
+
+  console.log(data) // logs something like 'http://localhost:...'
+}
+```
+
+```tsx
+function ExampleWithRefreshToken() {
+  const [refreshToken] = useState('foo')
+  const { data, isRefetching } = useMapStyleUrl({ refreshToken })
+
+  console.log(data) // logs something like 'http://localhost:...?refresh_token=foo'
+}
+```
+
+
+### getInvitesQueryKey
+
+| Function | Type |
+| ---------- | ---------- |
+| `getInvitesQueryKey` | `() => readonly ["@comapeo/react", "invites"]` |
+
+### getPendingInvitesQueryKey
+
+| Function | Type |
+| ---------- | ---------- |
+| `getPendingInvitesQueryKey` | `() => readonly ["@comapeo/react", "invites", { readonly status: "pending"; }]` |
+
+### pendingInvitesQueryOptions
+
+| Function | Type |
+| ---------- | ---------- |
+| `pendingInvitesQueryOptions` | `({ clientApi, }: { clientApi: MapeoClientApi; }) => OmitKeyof<UseQueryOptions<MapBuffers<InviteInternal>[], Error, MapBuffers<InviteInternal>[], QueryKey>, "queryFn"> and { ...; } and { ...; }` |
+
+
+## Constants
+
+- [ClientApiContext](#clientapicontext)
+- [ROOT_QUERY_KEY](#root_query_key)
+
+### ClientApiContext
+
+| Constant | Type |
+| ---------- | ---------- |
+| `ClientApiContext` | `Context<MapeoClientApi or null>` |
+
+### ROOT_QUERY_KEY
+
+| Constant | Type |
+| ---------- | ---------- |
+| `ROOT_QUERY_KEY` | `"@comapeo/react"` |
+
+
+
+## Types
+
+- [DocumentType](#documenttype)
+
+### DocumentType
+
+| Type | Type |
+| ---------- | ---------- |
+| `DocumentType` | `Extract< MapeoDoc['schemaName'], 'field' or 'observation' or 'preset' or 'track' or 'remoteDetectionAlert' >` |
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
 				"prettier": "^3.4.2",
 				"random-access-memory": "^6.2.1",
 				"rimraf": "^6.0.1",
+				"tsdoc-markdown": "^1.0.0",
 				"typescript": "^5.7.2",
 				"typescript-eslint": "^8.18.0",
 				"vitest": "^2.1.8"
@@ -9047,6 +9048,19 @@
 			},
 			"peerDependencies": {
 				"typescript": ">=4.2.0"
+			}
+		},
+		"node_modules/tsdoc-markdown": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/tsdoc-markdown/-/tsdoc-markdown-1.0.0.tgz",
+			"integrity": "sha512-XSuwiPUpiDLkrLnuzTF46nGbrRylDMrx1b0gyEBtiN9gjqxOMsRwQY1YJgZV8ulXYYHXXl5lxFbJ5Y5y0FxdiA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"tsdoc": "bin/index.js"
+			},
+			"peerDependencies": {
+				"typescript": "^5"
 			}
 		},
 		"node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"types": "tsc",
 		"test:unit": "vitest run",
 		"test": "npm-run-all --parallel --continue-on-error --print-label --aggregate-output types test:*",
+		"docs:generate": "tsdoc --src=src/contexts/*,src/hooks/*,src/lib/react-query/* --dest=docs/API.md --noemoji --types",
 		"build:clean": "rimraf ./dist",
 		"build:npm": "tsc -p tsconfig.npm.json",
 		"build": "npm-run-all build:clean build:npm",
@@ -68,6 +69,7 @@
 		"prettier": "^3.4.2",
 		"random-access-memory": "^6.2.1",
 		"rimraf": "^6.0.1",
+		"tsdoc-markdown": "^1.0.0",
 		"typescript": "^5.7.2",
 		"typescript-eslint": "^8.18.0",
 		"vitest": "^2.1.8"

--- a/src/contexts/ClientApi.ts
+++ b/src/contexts/ClientApi.ts
@@ -1,12 +1,22 @@
 import type { MapeoClientApi } from '@comapeo/ipc'
-import { createContext, createElement, type PropsWithChildren } from 'react'
+import { createContext, createElement, type ReactNode } from 'react'
 
 export const ClientApiContext = createContext<MapeoClientApi | null>(null)
 
+/**
+ * Create a context provider that holds a CoMapeo API client instance.
+ *
+ * @param {Object} opts
+ * @param {ReactNode} opts.children React children node
+ * @param {MapeoClientApi} opts.clientApi Client API instance
+ */
 export function ClientApiProvider({
 	children,
 	clientApi,
-}: PropsWithChildren<{ clientApi: MapeoClientApi }>) {
+}: {
+	children: ReactNode
+	clientApi: MapeoClientApi
+}) {
 	return createElement(
 		ClientApiContext.Provider,
 		{ value: clientApi },

--- a/src/hooks/client.ts
+++ b/src/hooks/client.ts
@@ -2,6 +2,31 @@ import { useContext } from 'react'
 
 import { ClientApiContext } from '../contexts/ClientApi'
 
+/**
+ * Access a client API instance. If a ClientApiContext provider is not
+ * set up, it will throw an error.
+ *
+ * @returns {import('@comapeo/ipc').MapeoClientApi} Client API instance
+ *
+ * @example
+ * ```tsx
+ * function ClientExample() {
+ *   return (
+ *     // Creation of clientApi omitted for brevity
+ *     <ClientApiContext.Provider clientApi={clientApi}>
+ *       <ComponentThatUsesClient />
+ *     </ClientApiContext.Provider>
+ *   )
+ * }
+ *
+ * function ComponentThatUsesClient() {
+ *   const clientApi = useClientApi()
+ *
+ *   // Rest omitted for brevity.
+ * }
+ * ```
+ *
+ */
 export function useClientApi() {
 	const clientApi = useContext(ClientApiContext)
 

--- a/src/hooks/device-info.ts
+++ b/src/hooks/device-info.ts
@@ -3,6 +3,17 @@ import { useSuspenseQuery } from '@tanstack/react-query'
 import { deviceInfoQueryOptions } from '../lib/react-query/device-info'
 import { useClientApi } from './client'
 
+/**
+ * Retrieve info about the current device.
+ *
+ * @example
+ * ```tsx
+ * function DeviceInfoExample() {
+ *   const { data, isRefetching } = useDeviceInfo()
+ * }
+ * ```
+ *
+ */
 export function useOwnDeviceInfo() {
 	const clientApi = useClientApi()
 

--- a/src/hooks/documents.ts
+++ b/src/hooks/documents.ts
@@ -9,6 +9,31 @@ import {
 import { useSingleProject } from './projects'
 
 // TODO: Return type is not narrowed properly by `docType`
+/**
+ * Retrieve a single document from the database based on the document's document ID.
+ *
+ * Triggers the closest error boundary if the document cannot be found
+ *
+ * @param {Object} opts
+ * @param {string} opts.projectId Project public ID
+ * @param {DocumentType} opts.docType Document type of interest
+ * @param {string} opts.docId Document ID
+ * @param {Object} [opts.opts]
+ * @param {string} [opts.opts.lang] Language to translate the document into
+ *
+ * @example
+ * ```tsx
+ * function SingleDocumentByDocIdExample() {
+ *   const { data, isRefetching } = useSingleDocByDocId({
+ *     projectId: '...',
+ *     docType: 'observation',
+ *     docId: '...',
+ *   })
+ *
+ *   console.log(data.schemaName) // logs 'observation'
+ * }
+ * ```
+ */
 export function useSingleDocByDocId<D extends DocumentType>({
 	projectId,
 	docType,
@@ -36,6 +61,31 @@ export function useSingleDocByDocId<D extends DocumentType>({
 }
 
 // TODO: Return type is not narrowed properly by `docType`
+/**
+ * Retrieve a single document from the database based on the document's version ID.
+ *
+ * Triggers the closest error boundary if the document cannot be found.
+ *
+ * @param {Object} opts
+ * @param {string} opts.projectId Project public ID
+ * @param {DocumentType} opts.docType Document type of interest
+ * @param {string} opts.versionId Document's version ID
+ * @param {Object} [opts.opts]
+ * @param {string} [opts.opts.lang] Language to translate the document into
+ *
+ *  * @example
+ * ```tsx
+ * function SingleDocumentByVersionIdExample() {
+ *   const { data, isRefetching } = useSingleDocByVersionId({
+ *     projectId: '...',
+ *     docType: 'observation',
+ *     docId: '...',
+ *   })
+ *
+ *   console.log(data.schemaName) // logs 'observation'
+ * }
+ * ```
+ */
 export function useSingleDocByVersionId<D extends DocumentType>({
 	projectId,
 	docType,
@@ -63,6 +113,42 @@ export function useSingleDocByVersionId<D extends DocumentType>({
 }
 
 // TODO: Return type is not narrowed properly by `docType`
+/**
+ * Retrieve all documents of a specific `docType`.
+ *
+ * @param {Object} opts
+ * @param {string} opts.projectId Project public ID
+ * @param {DocumentType} opts.docType Document type of interest
+ * @param {Object} [opts.opts]
+ * @param {boolean} [opts.opts.includeDeleted] Include documents that have been marked as deleted
+ * @param {string} [opts.opts.lang] Language to translate the documents into
+ *
+ * @example
+ * ```tsx
+ * function BasicExample() {
+ *   const { data, isRefetching } = useManyDocs({
+ *     projectId: '...',
+ *     docType: 'observations',
+ *   })
+ * }
+ * ```
+ *
+ * ```tsx
+ * function useAllObservations(opts) {
+ *   return useManyDocs({
+ *     ...opts,
+ *     docType: 'observations',
+ *   })
+ * }
+ *
+ * function useAllPresets(opts) {
+ *   return useManyDocs({
+ *     ...opts,
+ *     docType: 'presets',
+ *   })
+ * }
+ * ```
+ */
 export function useManyDocs<D extends DocumentType>({
 	projectId,
 	docType,

--- a/src/hooks/maps.ts
+++ b/src/hooks/maps.ts
@@ -3,6 +3,33 @@ import { useSuspenseQuery } from '@tanstack/react-query'
 import { mapStyleJsonUrlQueryOptions } from '../lib/react-query/maps'
 import { useClientApi } from './client'
 
+/**
+ * Get a URL that points to a StyleJSON resource served by the embedded HTTP server.
+ *
+ * If `opts.refreshToken` is specified, it will be appended to the returned URL as a search param. This is useful for forcing cache busting
+ * due to hidden internal details by consuming components (e.g. map component from MapLibre).
+ *
+ * @param {Object} opts
+ * @param {string} opts.refreshToken String to append to the returned value as a search param
+ *
+ * @example
+ * ```tsx
+ * function ExampleWithoutRefreshToken() {
+ *   const { data, isRefetching } = useMapStyleUrl()
+ *
+ *   console.log(data) // logs something like 'http://localhost:...'
+ * }
+ * ```
+ *
+ * ```tsx
+ * function ExampleWithRefreshToken() {
+ *   const [refreshToken] = useState('foo')
+ *   const { data, isRefetching } = useMapStyleUrl({ refreshToken })
+ *
+ *   console.log(data) // logs something like 'http://localhost:...?refresh_token=foo'
+ * }
+ * ```
+ */
 export function useMapStyleUrl({
 	refreshToken,
 }: {

--- a/src/hooks/projects.ts
+++ b/src/hooks/projects.ts
@@ -13,6 +13,21 @@ import {
 } from '../lib/react-query/projects'
 import { useClientApi } from './client'
 
+/**
+ * Retrieve the project settings for a project.
+ *
+ * @param {Object} opts
+ * @param {string} opts.projectId Project public ID
+ *
+ * @example
+ * ```tsx
+ * function BasicExample() {
+ *   const { data, isRefetching } = useProjectSettings({ projectId: '...' })
+ *
+ *   console.log(data.name)
+ * }
+ * ```
+ */
 export function useProjectSettings({ projectId }: { projectId: string }) {
 	const clientApi = useClientApi()
 
@@ -33,6 +48,21 @@ export function useProjectSettings({ projectId }: { projectId: string }) {
 	return { data, isRefetching }
 }
 
+/**
+ * Retrieve a project API instance for a project.
+ *
+ * This is mostly used internally by the other hooks and should only be used if certain project APIs are not exposed via the hooks.
+ *
+ * @param {Object} opts
+ * @param {string} opts.projectId Project public ID
+ *
+ * @example
+ * ```tsx
+ * function BasicExample() {
+ *   const { data, isRefetching } = useSingleProject({ projectId: '...' })
+ * }
+ * ```
+ */
 export function useSingleProject({ projectId }: { projectId: string }) {
 	const clientApi = useClientApi()
 
@@ -46,6 +76,18 @@ export function useSingleProject({ projectId }: { projectId: string }) {
 	return { data, isRefetching }
 }
 
+/**
+ * Retrieve project information for each project that exists.
+ *
+ * @example
+ * ```tsx
+ * function BasicExample() {
+ *   const { data, isRefetching } = useManyProjects()
+ *
+ *   console.log(data.map(project => project.name))
+ * }
+ * ```
+ */
 export function useManyProjects() {
 	const clientApi = useClientApi()
 
@@ -58,6 +100,22 @@ export function useManyProjects() {
 	return { data, isRefetching }
 }
 
+/**
+ * Retrieve a single member of a project.
+ *
+ * @param {Object} opts
+ * @param {string} opts.projectId Project public ID
+ * @param {deviceId} opts.projectId Device ID of interest
+ *
+ * @example
+ * ```tsx
+ * function BasicExample() {
+ *   const { data, isRefetching } = useSingleMember({ projectId: '...', deviceId: '...' })
+ *
+ *   console.log(data.role)
+ * }
+ * ```
+ */
 export function useSingleMember({
 	projectId,
 	deviceId,
@@ -78,6 +136,21 @@ export function useSingleMember({
 	return { data, isRefetching }
 }
 
+/**
+ * Retrieve all members of a project.
+ *
+ * @param {Object} opts
+ * @param {string} opts.projectId Project public ID
+ *
+ * @example
+ * ```tsx
+ * function BasicExample() {
+ *   const { data, isRefetching } = useManyMembers({ projectId: '...' })
+ *
+ *   console.log(data.role)
+ * }
+ * ```
+ */
 export function useManyMembers({ projectId }: { projectId: string }) {
 	const { data: projectApi } = useSingleProject({ projectId })
 
@@ -88,6 +161,44 @@ export function useManyMembers({ projectId }: { projectId: string }) {
 	return { data, isRefetching }
 }
 
+/**
+ * Retrieve a URL that points to icon resources served by the embedded HTTP server.
+ *
+ * _TODO: Explain bitmap opts vs svg opts_
+ *
+ * @param {Object} opts
+ * @param {string} opts.projectId Project public ID
+ * @param {string} opts.iconId Icon ID of interest
+ * @param {BitmapOpts | SvgOpts} opts.opts Parameters related to the mime type of the icon of interest
+ *
+ * @example
+ * ```tsx
+ * function PngExample() {
+ *   const { data, isRefetching } = useIconUrl({
+ *     projectId: '...',
+ *     iconId: '...',
+ *     opts: {
+ *       mimeType: 'image/png',
+ *       pixelDensity: 1,
+ *       size: 'medium'
+ *     }
+ *   })
+ * }
+ * ```
+ *
+ * ```tsx
+ * function SvgExample() {
+ *   const { data, isRefetching } = useIconUrl({
+ *     projectId: '...',
+ *     iconId: '...',
+ *     opts: {
+ *       mimeType: 'image/svg',
+ *       size: 'medium'
+ *     }
+ *   })
+ * }
+ * ```
+ */
 export function useIconUrl({
 	projectId,
 	iconId,
@@ -111,6 +222,58 @@ export function useIconUrl({
 	return { data, isRefetching }
 }
 
+/**
+ * Retrieve a URL that points to a desired blob resource.
+ *
+ * _TODO: Explain BlobId in more depth_
+ *
+ * @param {Object} opts
+ * @param {string} opts.projectId Project public Id
+ * @param {BlobId} opts.blobId Blob ID of the desired resource
+ *
+ * @example
+ * ```tsx
+ * function PhotoExample() {
+ *   const { data, isRefetching } = useAttachmentUrl({
+ *     projectId: '...',
+ *     blobId: {
+ *       type: 'photo',
+ *       variant: 'thumbnail',
+ *       name: '...',
+ *       driveId: '...',
+ *     }
+ *   })
+ * }
+ * ```
+ *
+ * ```tsx
+ * function AudioExample() {
+ *   const { data, isRefetching } = useAttachmentUrl({
+ *     projectId: '...',
+ *     blobId: {
+ *       type: 'audio',
+ *       variant: 'original',
+ *       name: '...',
+ *       driveId: '...',
+ *     }
+ *   })
+ * }
+ * ```
+ *
+ * ```tsx
+ * function VideoExample() {
+ *   const { data, isRefetching } = useAttachmentUrl({
+ *     projectId: '...',
+ *     blobId: {
+ *       type: 'video',
+ *       variant: 'original',
+ *       name: '...',
+ *       driveId: '...',
+ *     }
+ *   })
+ * }
+ * ```
+ */
 export function useAttachmentUrl({
 	projectId,
 	blobId,
@@ -132,6 +295,23 @@ export function useAttachmentUrl({
 }
 
 // TODO: Eventually remove in favor of this information being provided by the backend when retrieving documents
+/**
+ * Retrieve the device ID that created a document.
+ *
+ * @param {Object} opts
+ * @param {string} opts.projectId Project public ID
+ * @param {string} opts.originalVersionId Version ID of document
+ *
+ * @example
+ * ```tsx
+ * function BasicExample() {
+ *   const { data, isRefetching } = useDocumentCreatedBy({
+ *     projectId: '...',
+ *     originalVersionId: '...',
+ *   })
+ * }
+ * ```
+ */
 export function useDocumentCreatedBy({
 	projectId,
 	originalVersionId,


### PR DESCRIPTION
Initial attempt at setting up tooling to generate docs based on TS + JSDoc annotations.

Currently uses https://github.com/peterpeterparker/tsdoc-markdown/ to output a single file at `docs/API.md`. The result is pretty barebones but probably sufficient for our needs.

Remaining tasks (many of which will probably be follow-ups):

- Improve examples
- Annotate other public APIs (mostly the lib/react-query stuff)
- Set up a CI workflow to build docs on PRs