### PR TITLE
feat: enable usage in both CommonJS and ESM environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ node_modules/
 
 # package output directory
 dist/
+
+# tshy build output
+.tshy-build/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
 # Auto-generated
 docs/API.md
 CHANGELOG.md
+.tshy/
+.tshy-build/

--- a/.tshy/build.json
+++ b/.tshy/build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "../src",
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
+  }
+}

--- a/.tshy/commonjs.json
+++ b/.tshy/commonjs.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./build.json",
+  "include": [
+    "../src/**/*.ts",
+    "../src/**/*.cts",
+    "../src/**/*.tsx",
+    "../src/**/*.json"
+  ],
+  "exclude": [
+    "../src/**/*.mts",
+    "../src/package.json"
+  ],
+  "compilerOptions": {
+    "outDir": "../.tshy-build/commonjs"
+  }
+}

--- a/.tshy/esm.json
+++ b/.tshy/esm.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./build.json",
+  "include": [
+    "../src/**/*.ts",
+    "../src/**/*.mts",
+    "../src/**/*.tsx",
+    "../src/**/*.json"
+  ],
+  "exclude": [
+    "../src/package.json"
+  ],
+  "compilerOptions": {
+    "outDir": "../.tshy-build/esm"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
 				"random-access-memory": "^6.2.1",
 				"rimraf": "^6.0.1",
 				"tsdoc-markdown": "^1.1.0",
+				"tshy": "^3.0.2",
 				"typescript": "^5.7.2",
 				"typescript-eslint": "^8.18.1",
 				"vitest": "^2.1.8"
@@ -2929,6 +2930,20 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/anymatch": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/archiver": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
@@ -3250,6 +3265,19 @@
 			"license": "MIT",
 			"peer": true
 		},
+		"node_modules/binary-extensions": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+			"integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/binary-stream-equals": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/binary-stream-equals/-/binary-stream-equals-1.0.0.tgz",
@@ -3519,6 +3547,44 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 16"
+			}
+		},
+		"node_modules/chokidar": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+			"integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"anymatch": "~3.1.2",
+				"braces": "~3.0.2",
+				"glob-parent": "~5.1.2",
+				"is-binary-path": "~2.1.0",
+				"is-glob": "~4.0.1",
+				"normalize-path": "~3.0.0",
+				"readdirp": "~3.6.0"
+			},
+			"engines": {
+				"node": ">= 8.10.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/chokidar/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/chownr": {
@@ -6636,6 +6702,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/is-binary-path": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"binary-extensions": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/is-core-module": {
 			"version": "2.15.1",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
@@ -7770,19 +7849,6 @@
 				"node": ">=8.6"
 			}
 		},
-		"node_modules/micromatch/node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/mime": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-4.0.4.tgz",
@@ -7925,6 +7991,22 @@
 			"dependencies": {
 				"binary-stream-equals": "^1.0.0",
 				"same-data": "^1.0.0"
+			}
+		},
+		"node_modules/mkdirp": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+			"integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"mkdirp": "dist/cjs/src/bin.js"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/mkdirp-classic": {
@@ -8117,7 +8199,6 @@
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8652,6 +8733,19 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/pidtree": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
@@ -8718,6 +8812,19 @@
 			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.0.tgz",
 			"integrity": "sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw==",
 			"license": "MIT"
+		},
+		"node_modules/polite-json": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/polite-json/-/polite-json-5.0.0.tgz",
+			"integrity": "sha512-OLS/0XeUAcE8a2fdwemNja+udKgXNnY6yKVIXqAD2zVRx1KvY6Ato/rZ2vdzbxqYwPW0u6SCNC/bAMPNzpzxbw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
 		},
 		"node_modules/postcss": {
 			"version": "8.4.49",
@@ -9384,6 +9491,19 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/readdirp": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"picomatch": "^2.2.1"
+			},
+			"engines": {
+				"node": ">=8.10.0"
+			}
+		},
 		"node_modules/ready-resource": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ready-resource/-/ready-resource-1.1.1.tgz",
@@ -9468,6 +9588,23 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/resolve-import": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-import/-/resolve-import-2.0.0.tgz",
+			"integrity": "sha512-jpKjLibLuc8D1XEV2+7zb0aqN7I8d12u89g/v6IsgCzdVlccMQJq4TKkPw5fbhHdxhm7nbVtN+KvOTnjFf+nEA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"glob": "^11.0.0",
+				"walk-up-path": "^4.0.0"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/restore-cursor": {
@@ -10582,6 +10719,56 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/sync-content": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/sync-content/-/sync-content-2.0.1.tgz",
+			"integrity": "sha512-NI1mo514yFhr8pV/5Etvgh+pSBUIpoAKoiBIUwALVlQQNAwb40bTw8hhPFaip/dvv0GhpHVOq0vq8iY02ppLTg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"glob": "^11.0.0",
+				"mkdirp": "^3.0.1",
+				"path-scurry": "^2.0.0",
+				"rimraf": "^6.0.0",
+				"tshy": "^3.0.0"
+			},
+			"bin": {
+				"sync-content": "dist/esm/bin.mjs"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/sync-content/node_modules/lru-cache": {
+			"version": "11.0.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
+			"integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/sync-content/node_modules/path-scurry": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+			"integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/tar-fs": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
@@ -10885,6 +11072,71 @@
 			},
 			"peerDependencies": {
 				"typescript": "^5"
+			}
+		},
+		"node_modules/tshy": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/tshy/-/tshy-3.0.2.tgz",
+			"integrity": "sha512-8GkWnAfmNXxl8iDTZ1o2H4jdaj9H7HeDKkr5qd0ZhQBCNA41D3xqTyg2Ycs51VCfmjJ5e+0v9AUmD6ylAI9Bgw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"chalk": "^5.3.0",
+				"chokidar": "^3.6.0",
+				"foreground-child": "^3.1.1",
+				"minimatch": "^10.0.0",
+				"mkdirp": "^3.0.1",
+				"polite-json": "^5.0.0",
+				"resolve-import": "^2.0.0",
+				"rimraf": "^6.0.0",
+				"sync-content": "^2.0.1",
+				"typescript": "^5.5.3",
+				"walk-up-path": "^4.0.0"
+			},
+			"bin": {
+				"tshy": "dist/esm/index.js"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/tshy/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/tshy/node_modules/chalk": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/tshy/node_modules/minimatch": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+			"integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/tslib": {
@@ -11244,6 +11496,16 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/walk-up-path": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+			"integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/wcwidth": {

--- a/package.json
+++ b/package.json
@@ -18,32 +18,46 @@
 		"Andrew Chou <achou@awana.digital>"
 	],
 	"type": "module",
-	"module": "./dist/index.js",
-	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js"
-		}
+			"import": {
+				"types": "./dist/esm/index.d.ts",
+				"default": "./dist/esm/index.js"
+			},
+			"require": {
+				"types": "./dist/commonjs/index.d.ts",
+				"default": "./dist/commonjs/index.js"
+			}
+		},
+		"./package.json": "./package.json"
 	},
+	"main": "./dist/commonjs/index.js",
+	"types": "./dist/commonjs/index.d.ts",
+	"module": "./dist/esm/index.js",
 	"files": [
 		"CHANGELOG.md",
 		"dist/",
 		"docs/API.md"
 	],
+	"tshy": {
+		"project": "./tsconfig.build.json",
+		"selfLink": false,
+		"exports": {
+			".": "./src/index.ts",
+			"./package.json": "./package.json"
+		}
+	},
 	"scripts": {
-		"prepare": "husky",
+		"prepare:husky": "husky",
+		"prepare:tshy": "tshy",
+		"prepare": "npm-run-all --parallel prepare:*",
 		"lint:eslint": "eslint --cache .",
 		"lint:format": "prettier --cache --check .",
 		"lint": "npm-run-all --parallel --continue-on-error --print-label --aggregate-output lint:*",
 		"types": "tsc",
 		"test:unit": "vitest run",
 		"test": "npm-run-all --parallel --continue-on-error --print-label --aggregate-output types test:*",
-		"docs:generate": "tsdoc --src=src/contexts/*,src/hooks/*,src/lib/react-query/* --dest=docs/API.md --noemoji --types",
-		"build:clean": "rimraf ./dist",
-		"build:npm": "tsc -p tsconfig.npm.json",
-		"build": "npm-run-all build:clean build:npm",
-		"prepack": "npm run build"
+		"docs:generate": "tsdoc --src=src/contexts/*,src/hooks/*,src/lib/react-query/* --dest=docs/API.md --noemoji --types"
 	},
 	"peerDependencies": {
 		"@comapeo/core": "*",
@@ -75,6 +89,7 @@
 		"random-access-memory": "^6.2.1",
 		"rimraf": "^6.0.1",
 		"tsdoc-markdown": "^1.1.0",
+		"tshy": "^3.0.2",
 		"typescript": "^5.7.2",
 		"typescript-eslint": "^8.18.1",
 		"vitest": "^2.1.8"

--- a/src/contexts/ClientApi.ts
+++ b/src/contexts/ClientApi.ts
@@ -1,4 +1,4 @@
-import type { MapeoClientApi } from '@comapeo/ipc'
+import type { MapeoClientApi } from '@comapeo/ipc' with { 'resolution-mode': 'import' }
 import { createContext, createElement, type ReactNode } from 'react'
 
 export const ClientApiContext = createContext<MapeoClientApi | null>(null)

--- a/src/hooks/documents.ts
+++ b/src/hooks/documents.ts
@@ -1,4 +1,4 @@
-import type { MapeoDoc } from '@comapeo/schema'
+import type { MapeoDoc } from '@comapeo/schema' with { 'resolution-mode': 'import' }
 import { useSuspenseQuery } from '@tanstack/react-query'
 
 import {

--- a/src/hooks/projects.ts
+++ b/src/hooks/projects.ts
@@ -1,5 +1,8 @@
-import type { BitmapOpts, SvgOpts } from '@comapeo/core/dist/icon-api.js'
-import type { BlobId } from '@comapeo/core/dist/types.js'
+import type {
+	BitmapOpts,
+	SvgOpts,
+} from '@comapeo/core/dist/icon-api.js' with { 'resolution-mode': 'import' }
+import type { BlobId } from '@comapeo/core/dist/types.js' with { 'resolution-mode': 'import' }
 import { useSuspenseQuery } from '@tanstack/react-query'
 
 import {

--- a/src/lib/react-query/client.ts
+++ b/src/lib/react-query/client.ts
@@ -1,4 +1,4 @@
-import type { MapeoClientApi } from '@comapeo/ipc'
+import type { MapeoClientApi } from '@comapeo/ipc' with { 'resolution-mode': 'import' }
 import { queryOptions } from '@tanstack/react-query'
 
 import { baseQueryOptions, ROOT_QUERY_KEY } from './shared.js'

--- a/src/lib/react-query/documents.ts
+++ b/src/lib/react-query/documents.ts
@@ -1,5 +1,5 @@
-import type { MapeoProjectApi } from '@comapeo/ipc'
-import type { MapeoDoc } from '@comapeo/schema'
+import type { MapeoProjectApi } from '@comapeo/ipc' with { 'resolution-mode': 'import' }
+import type { MapeoDoc } from '@comapeo/schema' with { 'resolution-mode': 'import' }
 import { queryOptions } from '@tanstack/react-query'
 
 import { baseQueryOptions, ROOT_QUERY_KEY } from './shared.js'

--- a/src/lib/react-query/invites.ts
+++ b/src/lib/react-query/invites.ts
@@ -1,4 +1,4 @@
-import type { MapeoClientApi } from '@comapeo/ipc'
+import type { MapeoClientApi } from '@comapeo/ipc' with { 'resolution-mode': 'import' }
 import { queryOptions } from '@tanstack/react-query'
 
 import { baseQueryOptions, ROOT_QUERY_KEY } from './shared.js'

--- a/src/lib/react-query/maps.ts
+++ b/src/lib/react-query/maps.ts
@@ -1,4 +1,4 @@
-import type { MapeoClientApi } from '@comapeo/ipc'
+import type { MapeoClientApi } from '@comapeo/ipc' with { 'resolution-mode': 'import' }
 import { queryOptions } from '@tanstack/react-query'
 
 import { baseQueryOptions, ROOT_QUERY_KEY } from './shared.js'

--- a/src/lib/react-query/projects.ts
+++ b/src/lib/react-query/projects.ts
@@ -1,6 +1,12 @@
-import type { BitmapOpts, SvgOpts } from '@comapeo/core/dist/icon-api.js'
-import type { BlobId } from '@comapeo/core/dist/types.js'
-import type { MapeoClientApi, MapeoProjectApi } from '@comapeo/ipc'
+import type {
+	BitmapOpts,
+	SvgOpts,
+} from '@comapeo/core/dist/icon-api.js' with { 'resolution-mode': 'import' }
+import type { BlobId } from '@comapeo/core/dist/types.js' with { 'resolution-mode': 'import' }
+import type {
+	MapeoClientApi,
+	MapeoProjectApi,
+} from '@comapeo/ipc' with { 'resolution-mode': 'import' }
 import { queryOptions } from '@tanstack/react-query'
 
 import { baseQueryOptions, ROOT_QUERY_KEY } from './shared.js'

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,8 +2,7 @@
 	"extends": ["./tsconfig.json"],
 	"compilerOptions": {
 		"declaration": true,
-		"noEmit": false,
-		"outDir": "dist"
+		"noEmit": false
 	},
 	"include": ["src/**/*"],
 	"exclude": ["node_modules", "tests"]


### PR DESCRIPTION
Consumption of this module is used in a variety of environments where the tooling for module resolution is quite varied e.g:

- Metro, which is primarily CommonJS-first but has improving support for ESM-based modules based on some internal configurations
- Jest, which has limited ESM support out of the box
- Vite

Ideally I wanted to keep this module purely as an ESM-only module, but in early attempts of integrating with our applications (especially React Native), I've found it quite tedious to deal with the headaches of the tools due to differing support of pure ESM modules. To alleviate this headache, this PR introduces [tshy](https://github.com/isaacs/tshy) to set up dual publishing of both ESM and CommonJS. It's quite opinionated but it works sufficiently for the needs of this module.