### PR TITLE
chore: update retry option in baseQueryOptions()

### DIFF
--- a/src/lib/react-query/shared.ts
+++ b/src/lib/react-query/shared.ts
@@ -13,7 +13,7 @@ export const ROOT_QUERY_KEY = '@comapeo/core-react'
 export function baseQueryOptions() {
 	return {
 		networkMode: 'always',
-		retry: 0,
+		retry: false,
 	} satisfies QueryOptions
 }
 


### PR DESCRIPTION
Changes it from `0` to `false`, which shouldn't have any user-facing consequences.