### PR TITLE
feat!: implement write hooks for documents

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -23,6 +23,9 @@
 - [useSingleDocByDocId](#usesingledocbydocid)
 - [useSingleDocByVersionId](#usesingledocbyversionid)
 - [useManyDocs](#usemanydocs)
+- [useCreateDocument](#usecreatedocument)
+- [useUpdateDocument](#useupdatedocument)
+- [useDeleteDocument](#usedeletedocument)
 - [useAcceptInvite](#useacceptinvite)
 - [useRejectInvite](#userejectinvite)
 - [useSendInvite](#usesendinvite)
@@ -439,7 +442,7 @@ Triggers the closest error boundary if the document cannot be found
 
 | Function | Type |
 | ---------- | ---------- |
-| `useSingleDocByDocId` | `<D extends DocumentType>({ projectId, docType, docId, lang, }: { projectId: string; docType: D; docId: string; lang?: string or undefined; }) => ReadHookResult<Extract<{ schemaName: "deviceInfo"; name: string; deviceType: "device_type_unspecified" or ... 4 more ... or "UNRECOGNIZED"; ... 7 more ...; deleted: boolean; }...` |
+| `useSingleDocByDocId` | `<D extends WriteableDocumentType>({ projectId, docType, docId, lang, }: { projectId: string; docType: D; docId: string; lang?: string or undefined; }) => ReadHookResult<Extract<{ schemaName: "deviceInfo"; name: string; deviceType: "device_type_unspecified" or ... 4 more ... or "UNRECOGNIZED"; ... 7 more ...; deleted: b...` |
 
 Parameters:
 
@@ -472,7 +475,7 @@ Triggers the closest error boundary if the document cannot be found.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useSingleDocByVersionId` | `<D extends DocumentType>({ projectId, docType, versionId, lang, }: { projectId: string; docType: D; versionId: string; lang?: string or undefined; }) => ReadHookResult<Extract<{ schemaName: "deviceInfo"; name: string; deviceType: "device_type_unspecified" or ... 4 more ... or "UNRECOGNIZED"; ... 7 more ...; deleted: bo...` |
+| `useSingleDocByVersionId` | `<D extends WriteableDocumentType>({ projectId, docType, versionId, lang, }: { projectId: string; docType: D; versionId: string; lang?: string or undefined; }) => ReadHookResult<Extract<{ schemaName: "deviceInfo"; name: string; deviceType: "device_type_unspecified" or ... 4 more ... or "UNRECOGNIZED"; ... 7 more ...; de...` |
 
 Parameters:
 
@@ -505,7 +508,7 @@ Retrieve all documents of a specific `docType`.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useManyDocs` | `<D extends DocumentType>({ projectId, docType, includeDeleted, lang, }: { projectId: string; docType: D; includeDeleted?: boolean or undefined; lang?: string or undefined; }) => ReadHookResult<Extract<{ schemaName: "deviceInfo"; name: string; deviceType: "device_type_unspecified" or ... 4 more ... or "UNRECOGNIZED"; ......` |
+| `useManyDocs` | `<D extends WriteableDocumentType>({ projectId, docType, includeDeleted, lang, }: { projectId: string; docType: D; includeDeleted?: boolean or undefined; lang?: string or undefined; }) => ReadHookResult<Extract<{ schemaName: "deviceInfo"; name: string; deviceType: "device_type_unspecified" or ... 4 more ... or "UNRECOGNI...` |
 
 Parameters:
 
@@ -541,6 +544,48 @@ function useAllPresets(opts) {
   })
 }
 ```
+
+
+### useCreateDocument
+
+Create a document for a project.
+
+| Function | Type |
+| ---------- | ---------- |
+| `useCreateDocument` | `<D extends WriteableDocumentType>({ docType, projectId, }: { docType: D; projectId: string; }) => { mutate: UseMutateFunction<WriteableDocument<D> and { forks: string[]; }, Error, { value: Omit<WriteableValue<D>, "schemaName">; }, unknown>; reset: () => void; status: "pending" or ... 2 more ... or "idle"; }` |
+
+Parameters:
+
+* `opts.docType`: Document type to create.
+* `opts.projectId`: Public ID of project to create document for.
+
+
+### useUpdateDocument
+
+Update a document within a project.
+
+| Function | Type |
+| ---------- | ---------- |
+| `useUpdateDocument` | `<D extends WriteableDocumentType>({ docType, projectId, }: { docType: D; projectId: string; }) => { mutate: UseMutateFunction<WriteableDocument<D> and { forks: string[]; }, Error, { versionId: string; value: Omit<...>; }, unknown>; reset: () => void; status: "pending" or ... 2 more ... or "idle"; }` |
+
+Parameters:
+
+* `opts.docType`: Document type to update.
+* `opts.projectId`: Public ID of project document belongs to.
+
+
+### useDeleteDocument
+
+Delete a document within a project.
+
+| Function | Type |
+| ---------- | ---------- |
+| `useDeleteDocument` | `<D extends WriteableDocumentType>({ docType, projectId, }: { docType: D; projectId: string; }) => { mutate: UseMutateFunction<WriteableDocument<D> and { forks: string[]; }, Error, { docId: string; }, unknown>; reset: () => void; status: "pending" or ... 2 more ... or "idle"; }` |
+
+Parameters:
+
+* `opts.docType`: Document type to delete.
+* `opts.projectId`: Public ID of project document belongs to.
 
 
 ### useAcceptInvite

--- a/src/hooks/documents.ts
+++ b/src/hooks/documents.ts
@@ -1,11 +1,18 @@
 import type { MapeoDoc } from '@comapeo/schema' with { 'resolution-mode': 'import' }
-import { useSuspenseQuery } from '@tanstack/react-query'
+import {
+	useMutation,
+	useQueryClient,
+	useSuspenseQuery,
+} from '@tanstack/react-query'
 
 import {
+	createDocumentMutationOptions,
+	deleteDocumentMutationOptions,
 	documentByDocumentIdQueryOptions,
 	documentByVersionIdQueryOptions,
 	documentsQueryOptions,
-	type DocumentType,
+	updateDocumentMutationOptions,
+	type MutableDocumentType,
 } from '../lib/react-query/documents.js'
 import { useSingleProject } from './projects.js'
 
@@ -38,7 +45,7 @@ type ReadHookResult<D> = {
  * }
  * ```
  */
-export function useSingleDocByDocId<D extends DocumentType>({
+export function useSingleDocByDocId<D extends MutableDocumentType>({
 	projectId,
 	docType,
 	docId,
@@ -94,7 +101,7 @@ export function useSingleDocByDocId<D extends DocumentType>({
  * }
  * ```
  */
-export function useSingleDocByVersionId<D extends DocumentType>({
+export function useSingleDocByVersionId<D extends MutableDocumentType>({
 	projectId,
 	docType,
 	versionId,
@@ -159,7 +166,7 @@ export function useSingleDocByVersionId<D extends DocumentType>({
  * }
  * ```
  */
-export function useManyDocs<D extends DocumentType>({
+export function useManyDocs<D extends MutableDocumentType>({
 	projectId,
 	docType,
 	includeDeleted,
@@ -188,4 +195,88 @@ export function useManyDocs<D extends DocumentType>({
 		error,
 		isRefetching,
 	}
+}
+
+/**
+ * Create a document for a project.
+ *
+ * @param opts.docType Document type to create.
+ * @param opts.projectId Public ID of project to create document for.
+ */
+export function useCreateDocument<D extends MutableDocumentType>({
+	docType,
+	projectId,
+}: {
+	docType: D
+	projectId: string
+}) {
+	const queryClient = useQueryClient()
+	const { data: projectApi } = useSingleProject({ projectId })
+
+	const { mutate, reset, status } = useMutation(
+		createDocumentMutationOptions({
+			docType,
+			projectApi,
+			projectId,
+			queryClient,
+		}),
+	)
+
+	return { mutate, reset, status }
+}
+
+/**
+ * Update a document within a project.
+ *
+ * @param opts.docType Document type to update.
+ * @param opts.projectId Public ID of project document belongs to.
+ */
+export function useUpdateDocument<D extends MutableDocumentType>({
+	docType,
+	projectId,
+}: {
+	docType: D
+	projectId: string
+}) {
+	const queryClient = useQueryClient()
+	const { data: projectApi } = useSingleProject({ projectId })
+
+	const { mutate, reset, status } = useMutation(
+		updateDocumentMutationOptions({
+			docType,
+			projectApi,
+			projectId,
+			queryClient,
+		}),
+	)
+
+	return { mutate, reset, status }
+}
+
+/**
+ * Delete a document within a project.
+ *
+ * @param opts.docType Document type to delete.
+ * @param opts.projectId Public ID of project document belongs to.
+ */
+export function useDeleteDocument<D extends MutableDocumentType>({
+	docType,
+	projectId,
+}: {
+	docType: D
+	projectId: string
+}) {
+	const queryClient = useQueryClient()
+	const { data: projectApi } = useSingleProject({ projectId })
+
+	const { mutate, reset, status } = useMutation(
+		deleteDocumentMutationOptions({
+			docType,
+			projectApi,
+			projectId,
+			queryClient,
+		}),
+	)
+
+	return { mutate, reset, status }
 }

--- a/src/hooks/documents.ts
+++ b/src/hooks/documents.ts
@@ -12,7 +12,7 @@ import {
 	documentByVersionIdQueryOptions,
 	documentsQueryOptions,
 	updateDocumentMutationOptions,
-	type MutableDocumentType,
+	type WriteableDocumentType,
 } from '../lib/react-query/documents.js'
 import { useSingleProject } from './projects.js'
 
@@ -45,7 +45,7 @@ type ReadHookResult<D> = {
  * }
  * ```
  */
-export function useSingleDocByDocId<D extends MutableDocumentType>({
+export function useSingleDocByDocId<D extends WriteableDocumentType>({
 	projectId,
 	docType,
 	docId,
@@ -101,7 +101,7 @@ export function useSingleDocByDocId<D extends MutableDocumentType>({
  * }
  * ```
  */
-export function useSingleDocByVersionId<D extends MutableDocumentType>({
+export function useSingleDocByVersionId<D extends WriteableDocumentType>({
 	projectId,
 	docType,
 	versionId,
@@ -166,7 +166,7 @@ export function useSingleDocByVersionId<D extends MutableDocumentType>({
  * }
  * ```
  */
-export function useManyDocs<D extends MutableDocumentType>({
+export function useManyDocs<D extends WriteableDocumentType>({
 	projectId,
 	docType,
 	includeDeleted,
@@ -203,7 +203,7 @@ export function useManyDocs<D extends MutableDocumentType>({
  * @param opts.docType Document type to create.
  * @param opts.projectId Public ID of project to create document for.
  */
-export function useCreateDocument<D extends MutableDocumentType>({
+export function useCreateDocument<D extends WriteableDocumentType>({
 	docType,
 	projectId,
 }: {
@@ -231,7 +231,7 @@ export function useCreateDocument<D extends MutableDocumentType>({
  * @param opts.docType Document type to update.
  * @param opts.projectId Public ID of project document belongs to.
  */
-export function useUpdateDocument<D extends MutableDocumentType>({
+export function useUpdateDocument<D extends WriteableDocumentType>({
 	docType,
 	projectId,
 }: {
@@ -259,7 +259,7 @@ export function useUpdateDocument<D extends MutableDocumentType>({
  * @param opts.docType Document type to delete.
  * @param opts.projectId Public ID of project document belongs to.
  */
-export function useDeleteDocument<D extends MutableDocumentType>({
+export function useDeleteDocument<D extends WriteableDocumentType>({
 	docType,
 	projectId,
 }: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,9 +47,9 @@ export {
 	getDocumentByVersionIdQueryKey,
 	getDocumentsQueryKey,
 	getManyDocumentsQueryKey,
-	type MutableDocument,
-	type MutableDocumentType,
-	type MutableValue,
+	type WriteableDocument,
+	type WriteableDocumentType,
+	type WriteableValue,
 } from './lib/react-query/documents.js'
 export {
 	getInvitesQueryKey,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,12 @@ export {
 	useSetOwnDeviceInfo,
 } from './hooks/client.js'
 export {
+	useCreateDocument,
+	useDeleteDocument,
 	useManyDocs,
 	useSingleDocByDocId,
 	useSingleDocByVersionId,
+	useUpdateDocument,
 } from './hooks/documents.js'
 export {
 	useAcceptInvite,
@@ -44,7 +47,9 @@ export {
 	getDocumentByVersionIdQueryKey,
 	getDocumentsQueryKey,
 	getManyDocumentsQueryKey,
-	type DocumentType,
+	type MutableDocument,
+	type MutableDocumentType,
+	type MutableValue,
 } from './lib/react-query/documents.js'
 export {
 	getInvitesQueryKey,

--- a/src/lib/react-query/documents.ts
+++ b/src/lib/react-query/documents.ts
@@ -15,20 +15,20 @@ import {
 	ROOT_QUERY_KEY,
 } from './shared.js'
 
-export type MutableDocumentType = Extract<
+export type WriteableDocumentType = Extract<
 	MapeoDoc['schemaName'],
 	'field' | 'observation' | 'preset' | 'track' | 'remoteDetectionAlert'
 >
-export type MutableValue<D extends MutableDocumentType> = Extract<
+export type WriteableValue<D extends WriteableDocumentType> = Extract<
 	MapeoValue,
 	{ schemaName: D }
 >
-export type MutableDocument<D extends MutableDocumentType> = Extract<
+export type WriteableDocument<D extends WriteableDocumentType> = Extract<
 	MapeoDoc,
 	{ schemaName: D }
 >
 
-export function getDocumentsQueryKey<D extends MutableDocumentType>({
+export function getDocumentsQueryKey<D extends WriteableDocumentType>({
 	projectId,
 	docType,
 }: {
@@ -38,7 +38,7 @@ export function getDocumentsQueryKey<D extends MutableDocumentType>({
 	return [ROOT_QUERY_KEY, 'projects', projectId, docType] as const
 }
 
-export function getManyDocumentsQueryKey<D extends MutableDocumentType>({
+export function getManyDocumentsQueryKey<D extends WriteableDocumentType>({
 	projectId,
 	docType,
 	includeDeleted,
@@ -58,7 +58,7 @@ export function getManyDocumentsQueryKey<D extends MutableDocumentType>({
 	] as const
 }
 
-export function getDocumentByDocIdQueryKey<D extends MutableDocumentType>({
+export function getDocumentByDocIdQueryKey<D extends WriteableDocumentType>({
 	projectId,
 	docType,
 	docId,
@@ -79,7 +79,9 @@ export function getDocumentByDocIdQueryKey<D extends MutableDocumentType>({
 	] as const
 }
 
-export function getDocumentByVersionIdQueryKey<D extends MutableDocumentType>({
+export function getDocumentByVersionIdQueryKey<
+	D extends WriteableDocumentType,
+>({
 	projectId,
 	docType,
 	versionId,
@@ -100,7 +102,7 @@ export function getDocumentByVersionIdQueryKey<D extends MutableDocumentType>({
 	] as const
 }
 
-export function documentsQueryOptions<D extends MutableDocumentType>({
+export function documentsQueryOptions<D extends WriteableDocumentType>({
 	projectApi,
 	projectId,
 	docType,
@@ -131,7 +133,7 @@ export function documentsQueryOptions<D extends MutableDocumentType>({
 }
 
 export function documentByDocumentIdQueryOptions<
-	D extends MutableDocumentType,
+	D extends WriteableDocumentType,
 >({
 	projectApi,
 	projectId,
@@ -163,7 +165,9 @@ export function documentByDocumentIdQueryOptions<
 	})
 }
 
-export function documentByVersionIdQueryOptions<D extends MutableDocumentType>({
+export function documentByVersionIdQueryOptions<
+	D extends WriteableDocumentType,
+>({
 	projectApi,
 	projectId,
 	docType,
@@ -190,7 +194,7 @@ export function documentByVersionIdQueryOptions<D extends MutableDocumentType>({
 	})
 }
 
-export function createDocumentMutationOptions<D extends MutableDocumentType>({
+export function createDocumentMutationOptions<D extends WriteableDocumentType>({
 	docType,
 	projectApi,
 	projectId,
@@ -205,7 +209,7 @@ export function createDocumentMutationOptions<D extends MutableDocumentType>({
 		...baseMutationOptions(),
 		mutationFn: async ({
 			value,
-		}): Promise<MutableDocument<D> & { forks: Array<string> }> => {
+		}): Promise<WriteableDocument<D> & { forks: Array<string> }> => {
 			// @ts-expect-error TS not handling this well
 			return projectApi[docType].create({
 				...value,
@@ -221,13 +225,13 @@ export function createDocumentMutationOptions<D extends MutableDocumentType>({
 			})
 		},
 	} satisfies UseMutationOptions<
-		MutableDocument<D> & { forks: Array<string> },
+		WriteableDocument<D> & { forks: Array<string> },
 		Error,
-		{ value: Omit<MutableValue<D>, 'schemaName'> }
+		{ value: Omit<WriteableValue<D>, 'schemaName'> }
 	>
 }
 
-export function updateDocumentMutationOptions<D extends MutableDocumentType>({
+export function updateDocumentMutationOptions<D extends WriteableDocumentType>({
 	docType,
 	projectApi,
 	projectId,
@@ -243,7 +247,7 @@ export function updateDocumentMutationOptions<D extends MutableDocumentType>({
 		mutationFn: async ({
 			versionId,
 			value,
-		}): Promise<MutableDocument<D> & { forks: Array<string> }> => {
+		}): Promise<WriteableDocument<D> & { forks: Array<string> }> => {
 			// @ts-expect-error TS not handling this well
 			return projectApi[docType].update(versionId, value)
 		},
@@ -256,16 +260,16 @@ export function updateDocumentMutationOptions<D extends MutableDocumentType>({
 			})
 		},
 	} satisfies UseMutationOptions<
-		MutableDocument<D> & { forks: Array<string> },
+		WriteableDocument<D> & { forks: Array<string> },
 		Error,
 		{
 			versionId: string
-			value: Omit<MutableValue<D>, 'schemaName'>
+			value: Omit<WriteableValue<D>, 'schemaName'>
 		}
 	>
 }
 
-export function deleteDocumentMutationOptions<D extends MutableDocumentType>({
+export function deleteDocumentMutationOptions<D extends WriteableDocumentType>({
 	docType,
 	projectApi,
 	projectId,
@@ -280,7 +284,7 @@ export function deleteDocumentMutationOptions<D extends MutableDocumentType>({
 		...baseMutationOptions(),
 		mutationFn: async ({
 			docId,
-		}): Promise<MutableDocument<D> & { forks: Array<string> }> => {
+		}): Promise<WriteableDocument<D> & { forks: Array<string> }> => {
 			// @ts-expect-error TS not handling this well
 			return projectApi[docType].delete(docId)
 		},
@@ -293,7 +297,7 @@ export function deleteDocumentMutationOptions<D extends MutableDocumentType>({
 			})
 		},
 	} satisfies UseMutationOptions<
-		MutableDocument<D> & { forks: Array<string> },
+		WriteableDocument<D> & { forks: Array<string> },
 		Error,
 		{ docId: string }
 	>

--- a/src/lib/react-query/documents.ts
+++ b/src/lib/react-query/documents.ts
@@ -262,10 +262,7 @@ export function updateDocumentMutationOptions<D extends WriteableDocumentType>({
 	} satisfies UseMutationOptions<
 		WriteableDocument<D> & { forks: Array<string> },
 		Error,
-		{
-			versionId: string
-			value: Omit<WriteableValue<D>, 'schemaName'>
-		}
+		{ versionId: string; value: Omit<WriteableValue<D>, 'schemaName'> }
 	>
 }
 


### PR DESCRIPTION
Closes #20 

Introduces the following write hooks:

- `useCreateDocument()`
- `useUpdateDocument()`
- `useDeleteDocument()`

The idea is for the consuming application to wrap these hooks if they want the convenience of hooks scoped to a writeable data type e.g.

```ts
function useCreateObservation() {
  const projectId = useCurrentProjectId()
  return useCreateDocument({ docType: 'observation', projectId: projectId })
}

function App() {
  const createObservation = useCreateObservation()
  
  function onPress() {
    createObservation.mutate({ ... }, { onSuccess: (observationDoc) => { ... } })
  }
}
```
Notes:

- Missing in this implementation is being able to specify an `attachmentsToAdd` opts. Since this only applies to observations, I was trying - and failing - to have the implementation elegantly handle the polymorphism from a types perspective. For now, will consider that to be an enhancement that can be implemented later if really needed. Will create a more specific issue for this after this has been merged.

- Renames a type that's exported from the package, hence the breaking change notice.