### PR TITLE
fix: updating own device info should invalidate reads related to project members

### DIFF
--- a/src/lib/react-query/client.ts
+++ b/src/lib/react-query/client.ts
@@ -6,6 +6,7 @@ import {
 	type QueryClient,
 } from '@tanstack/react-query'
 
+import { getProjectsQueryKey } from './projects.js'
 import {
 	baseMutationOptions,
 	baseQueryOptions,
@@ -67,6 +68,9 @@ export function setOwnDeviceInfoMutationOptions({
 		onSuccess: () => {
 			queryClient.invalidateQueries({
 				queryKey: getDeviceInfoQueryKey(),
+			})
+			queryClient.invalidateQueries({
+				queryKey: getProjectsQueryKey(),
 			})
 		},
 	} satisfies MutationOptions<


### PR DESCRIPTION
The information set by using `ClientApi.setDeviceInfo()` is also reflected when retrieving member info for your own device in a project. The corresponding write hook is updated such that the relevant invalidation occurs