### PR TITLE
fix: address edge case for reading map stylejson url

### DIFF
--- a/src/lib/react-query/maps.ts
+++ b/src/lib/react-query/maps.ts
@@ -27,7 +27,12 @@ export function mapStyleJsonUrlQueryOptions({
 		queryKey: getStyleJsonUrlQueryKey({ refreshToken }),
 		queryFn: async () => {
 			const result = await clientApi.getMapStyleJsonUrl()
-			return refreshToken ? result + `?refresh_token=${refreshToken}` : result
+
+			if (!refreshToken) return result
+
+			const u = new URL(result)
+			u.searchParams.set('refresh_token', refreshToken)
+			return u.href
 		},
 	})
 }


### PR DESCRIPTION
Unlikely to happen, but prevents an issue that would occur if core returns a URL that already has search params and the end-user of the hook uses the `refreshToken` option