### PR TITLE
chore(tests): initial tests for hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
-      - run: npm run test
+      - name: Run type checks
+        run: npm run types
+      - name: Run tests
+        run: npm run test

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -12,4 +12,4 @@ npm install
 
 ## Running tests
 
-Unit tests can be run using `npm test` (or `npm t`).
+Tests can be run using `npm test` (or `npm t`).

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
 		"lint:format": "prettier --cache --check .",
 		"lint": "npm-run-all --parallel --continue-on-error --print-label --aggregate-output lint:*",
 		"types": "tsc",
-		"test:unit": "vitest run",
-		"test": "npm-run-all --parallel --continue-on-error --print-label --aggregate-output types test:*",
+		"test": "vitest run",
 		"docs:generate": "tsdoc --src=src/contexts/*,src/hooks/* --dest=docs/API.md --noemoji --types"
 	},
 	"peerDependencies": {

--- a/test/helpers/react.tsx
+++ b/test/helpers/react.tsx
@@ -6,14 +6,16 @@ import { ClientApiProvider } from '../../src/index.js'
 
 export function createClientApiWrapper({
 	clientApi,
+	queryClient,
 }: {
 	clientApi: MapeoClientApi
+	queryClient?: QueryClient
 }) {
-	const queryClient = new QueryClient()
+	const qc = queryClient || new QueryClient()
 
 	return ({ children }: PropsWithChildren<unknown>) => {
 		return (
-			<QueryClientProvider client={queryClient}>
+			<QueryClientProvider client={qc}>
 				<ClientApiProvider clientApi={clientApi}>{children}</ClientApiProvider>
 			</QueryClientProvider>
 		)

--- a/test/hooks/client.test.tsx
+++ b/test/hooks/client.test.tsx
@@ -1,40 +1,179 @@
-import { MapeoClientApi } from '@comapeo/ipc'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { renderHook } from '@testing-library/react'
-import { assert, assertType, test } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { assert, describe, test } from 'vitest'
 
-import { useClientApi } from '../../src/hooks/client.js'
+import {
+	useClientApi,
+	useIsArchiveDevice,
+	useOwnDeviceInfo,
+	useSetIsArchiveDevice,
+	useSetOwnDeviceInfo,
+} from '../../src/index.js'
 import { setupCoreIpc } from '../helpers/ipc.js'
 import { createClientApiWrapper } from '../helpers/react.js'
 
-test('useClientApi() throws when ClientApiProvider is not set up', () => {
-	const queryClient = new QueryClient()
+describe('useClientApi()', () => {
+	test('throws when ClientApiProvider is not set up', () => {
+		const queryClient = new QueryClient()
 
-	assert.throws(() => {
-		renderHook(() => useClientApi(), {
-			wrapper: ({ children }) => {
-				return (
-					<QueryClientProvider client={queryClient}>
-						{children}
-					</QueryClientProvider>
-				)
-			},
+		assert.throws(() => {
+			renderHook(() => useClientApi(), {
+				wrapper: ({ children }) => {
+					return (
+						<QueryClientProvider client={queryClient}>
+							{children}
+						</QueryClientProvider>
+					)
+				},
+			})
+		}, 'No client API set')
+	})
+
+	test('returns client api instance when ClientApiProvider is set up properly', (t) => {
+		const { client, cleanup } = setupCoreIpc()
+
+		t.onTestFinished(() => {
+			return cleanup()
 		})
-	}, 'No client API set')
+
+		const { result } = renderHook(() => useClientApi(), {
+			wrapper: createClientApiWrapper({ clientApi: client }),
+		})
+
+		assert.isDefined(result.current, 'client is set up properly')
+	})
 })
 
-test('useClientApi() returns client api instance when ClientApiProvider is set up properly', (t) => {
-	const { client, cleanup } = setupCoreIpc()
+describe('device info', () => {
+	test('basic read and write', async (t) => {
+		const { client, cleanup } = setupCoreIpc()
 
-	t.onTestFinished(() => {
-		return cleanup()
+		t.onTestFinished(() => {
+			return cleanup()
+		})
+
+		const queryClient = new QueryClient()
+
+		const wrapper = createClientApiWrapper({ clientApi: client, queryClient })
+
+		const readHook = renderHook(() => useOwnDeviceInfo(), { wrapper })
+		const writeHook = renderHook(() => useSetOwnDeviceInfo(), { wrapper })
+
+		// Since the read hook is Suspense-based, we need to simulate waiting for the data to initially resolve
+		await waitFor(() => {
+			assert.isNotNull(readHook.result.current.data)
+		})
+
+		const expectedDeviceId = await client.deviceId()
+
+		// 1. Initial state
+		assert.deepStrictEqual(
+			readHook.result.current,
+			{
+				data: {
+					deviceId: expectedDeviceId,
+					deviceType: 'device_type_unspecified',
+				},
+				isRefetching: false,
+				error: null,
+			},
+			'read hook has expected initial state',
+		)
+		assert.deepStrictEqual(
+			writeHook.result.current.status,
+			'idle',
+			'write hook has expected initial status',
+		)
+
+		// 2. Simulate a user interaction
+		act(() => {
+			writeHook.result.current.mutate({
+				name: 'my device',
+				deviceType: 'tablet',
+			})
+		})
+
+		// 3. Write hook lifecycle
+		// TODO: Ideally check for status === 'pending' before this
+		await waitFor(() => {
+			assert.strictEqual(writeHook.result.current.status, 'success')
+		})
+
+		// 4. Read hook lifecycle
+		// TODO: Ideally check for isRefetching === true before this
+		await waitFor(() => {
+			assert.strictEqual(readHook.result.current.isRefetching, false)
+		})
+
+		assert.deepStrictEqual(
+			readHook.result.current,
+			{
+				isRefetching: false,
+				error: null,
+				data: {
+					deviceId: expectedDeviceId,
+					name: 'my device',
+					deviceType: 'tablet',
+				},
+			},
+			'read hook has expected updated state',
+		)
 	})
+})
 
-	const { result } = renderHook(() => useClientApi(), {
-		wrapper: createClientApiWrapper({ clientApi: client }),
+describe('is archive device', () => {
+	test('basic read and write', async (t) => {
+		const { client, cleanup } = setupCoreIpc()
+
+		t.onTestFinished(() => {
+			return cleanup()
+		})
+
+		const queryClient = new QueryClient()
+
+		const wrapper = createClientApiWrapper({ clientApi: client, queryClient })
+
+		const readHook = renderHook(() => useIsArchiveDevice(), { wrapper })
+		const writeHook = renderHook(() => useSetIsArchiveDevice(), { wrapper })
+
+		// Since the hook is Suspense-based, we need to simulate waiting for the data to initially resolve
+		await waitFor(() => {
+			assert.isNotNull(readHook.result.current.data)
+		})
+
+		// 1. Initial state
+		assert.deepStrictEqual(
+			readHook.result.current,
+			{
+				data: true,
+				error: null,
+				isRefetching: false,
+			},
+			'read hook has expected initial state',
+		)
+		assert.deepStrictEqual(
+			writeHook.result.current.status,
+			'idle',
+			'write hook has expected initial status',
+		)
+
+		// 2. Simulate a user interaction
+		act(() => {
+			writeHook.result.current.mutate({ isArchiveDevice: false })
+		})
+
+		// 3. Write hook lifecycle
+		// TODO: Ideally check for status === 'pending' before this
+		await waitFor(() => {
+			assert.strictEqual(writeHook.result.current.status, 'success')
+		})
+
+		// 4. Read hook lifecycle
+		// TODO: Ideally check for isRefetching === true before this
+		await waitFor(() => {
+			assert.strictEqual(readHook.result.current.isRefetching, false)
+		})
+
+		assert.strictEqual(readHook.result.current.data, false, 'data has updated')
 	})
-
-	assertType<MapeoClientApi>(result.current)
-
-	assert.isDefined(result.current, 'client is set up properly')
 })

--- a/test/hooks/maps.test.tsx
+++ b/test/hooks/maps.test.tsx
@@ -1,0 +1,57 @@
+import { QueryClient } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { assert, test } from 'vitest'
+
+import { useMapStyleUrl } from '../../src/index.js'
+import { setupCoreIpc } from '../helpers/ipc.js'
+import { createClientApiWrapper } from '../helpers/react.js'
+
+test('basic read works', async (t) => {
+	const { client, cleanup, fastifyController } = setupCoreIpc()
+
+	fastifyController.start()
+
+	t.onTestFinished(() => {
+		return cleanup()
+	})
+
+	const queryClient = new QueryClient()
+
+	const wrapper = createClientApiWrapper({ clientApi: client, queryClient })
+
+	const mapStyleUrlHook = renderHook<
+		ReturnType<typeof useMapStyleUrl>,
+		Parameters<typeof useMapStyleUrl>[0]
+	>(({ refreshToken } = {}) => useMapStyleUrl({ refreshToken }), {
+		wrapper,
+	})
+
+	await waitFor(() => {
+		assert(mapStyleUrlHook.result.current.data !== null)
+	})
+
+	const url1 = new URL(mapStyleUrlHook.result.current.data)
+
+	assert(url1, 'map style url hook returns valid URL')
+
+	mapStyleUrlHook.rerender({ refreshToken: 'abc_123' })
+
+	// TODO: Ideally check for isRefetching === true before this
+	await waitFor(() => {
+		assert(mapStyleUrlHook.result.current.isRefetching === false)
+	})
+
+	const url2 = new URL(mapStyleUrlHook.result.current.data)
+
+	assert.notStrictEqual(
+		url2.href,
+		url1.href,
+		'map style url hook updates after changing refresh token option',
+	)
+
+	assert.strictEqual(
+		url2.searchParams.get('refresh_token'),
+		'abc_123',
+		'map style url has search param containing refresh token',
+	)
+})

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,13 @@
+import { notifyManager } from '@tanstack/react-query'
+import { act, cleanup } from '@testing-library/react'
+import { afterEach } from 'vitest'
+
+afterEach(() => {
+	// https://testing-library.com/docs/react-testing-library/api#cleanup
+	cleanup()
+})
+
+// Wrap notifications with act to make sure React knows about React Query updates
+notifyManager.setNotifyFunction((fn) => {
+	act(fn)
+})

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -3,5 +3,6 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
 	test: {
 		environment: 'happy-dom',
+		setupFiles: ['./test/setup.ts'],
 	},
 })


### PR DESCRIPTION
Introduces tests for hooks related to:

- top-level API client
- maps

Also updates the `test` npm script to only run vitest tests