### PR TITLE
feat!: introduce hook for invalidating reads

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -26,6 +26,7 @@
 - [useCreateDocument](#usecreatedocument)
 - [useUpdateDocument](#useupdatedocument)
 - [useDeleteDocument](#usedeletedocument)
+- [useInvalidateRead](#useinvalidateread)
 - [useAcceptInvite](#useacceptinvite)
 - [useRejectInvite](#userejectinvite)
 - [useSendInvite](#usesendinvite)
@@ -586,6 +587,34 @@ Parameters:
 
 * `opts.docType`: Document type to delete.
 * `opts.projectId`: Public ID of project document belongs to.
+
+
+### useInvalidateRead
+
+Provides a function that invalidates a specified read when called.
+
+| Function | Type |
+| ---------- | ---------- |
+| `useInvalidateRead` | `() => <Path extends keyof typeof PATH_TO_QUERY_KEY_FACTORY>(path: Path, params: Parameters<{ readonly '/': () => string; readonly '/maps': () => readonly ["@comapeo/core-react", "maps"]; readonly '/maps/styleJsonUrl': ({ refreshToken, }: { refreshToken?: string or undefined; }) => readonly [...]; ... 16 more ...; rea...` |
+
+Examples:
+
+```tsx
+function App() {
+  const invalidateRead = useInvalidateRead()
+
+  return (
+    <button
+      onClick={() => {
+        // Invalidate all reads!
+        invalidateRead('/', undefined)
+      }}
+    >
+      Invalidate everything!
+    </button>
+  )
+}
+```
 
 
 ### useAcceptInvite

--- a/src/hooks/documents.ts
+++ b/src/hooks/documents.ts
@@ -12,8 +12,8 @@ import {
 	documentByVersionIdQueryOptions,
 	documentsQueryOptions,
 	updateDocumentMutationOptions,
-	type WriteableDocumentType,
 } from '../lib/react-query/documents.js'
+import type { WriteableDocumentType } from '../lib/types.js' with { 'resolution-mode': 'import' }
 import { useSingleProject } from './projects.js'
 
 type ReadHookResult<D> = {

--- a/src/hooks/invalidation.ts
+++ b/src/hooks/invalidation.ts
@@ -1,0 +1,109 @@
+import { useQueryClient } from '@tanstack/react-query'
+
+import {
+	getClientQueryKey,
+	getDeviceInfoQueryKey,
+	getIsArchiveDeviceQueryKey,
+} from '../lib/react-query/client.js'
+import {
+	getDocumentByDocIdQueryKey,
+	getDocumentByVersionIdQueryKey,
+	getDocumentsQueryKey,
+	getManyDocumentsQueryKey,
+} from '../lib/react-query/documents.js'
+import {
+	getInvitesQueryKey,
+	getPendingInvitesQueryKey,
+} from '../lib/react-query/invites.js'
+import {
+	getMapsQueryKey,
+	getStyleJsonUrlQueryKey,
+} from '../lib/react-query/maps.js'
+import {
+	getAttachmentUrlQueryKey,
+	getDocumentCreatedByQueryKey,
+	getIconUrlQueryKey,
+	getMemberByIdQueryKey,
+	getMembersQueryKey,
+	getProjectByIdQueryKey,
+	getProjectRoleQueryKey,
+	getProjectSettingsQueryKey,
+	getProjectsQueryKey,
+} from '../lib/react-query/projects.js'
+import { ROOT_QUERY_KEY } from '../lib/react-query/shared.js'
+
+export const PATH_TO_QUERY_KEY_FACTORY = {
+	'/': () => [ROOT_QUERY_KEY] as const,
+	'/maps': getMapsQueryKey,
+	'/maps/styleJsonUrl': getStyleJsonUrlQueryKey,
+	'/invites': getInvitesQueryKey,
+	'/invites/pending': getPendingInvitesQueryKey,
+	'/client': getClientQueryKey,
+	'/client/deviceInfo': getDeviceInfoQueryKey,
+	'/client/isArchiveDevice': getIsArchiveDeviceQueryKey,
+	'/projects': getProjectsQueryKey,
+	'/projects/:projectId': getProjectByIdQueryKey,
+	'/projects/:projectId/settings': getProjectSettingsQueryKey,
+	'/projects/:projectId/role': getProjectRoleQueryKey,
+	'/projects/:projectId/members': getMembersQueryKey,
+	'/projects/:projectId/members/:deviceId': getMemberByIdQueryKey,
+	'/projects/:projectId/icons/:iconId': getIconUrlQueryKey,
+	'/projects/:projectId/documentCreatedBy/:originalVersionId':
+		getDocumentCreatedByQueryKey,
+	'/projects/:projectId/attachments/:blobId': getAttachmentUrlQueryKey,
+	'/projects/:projectId/:docType': (
+		opts: Parameters<
+			typeof getDocumentsQueryKey | typeof getManyDocumentsQueryKey
+		>[0],
+	) => {
+		if ('lang' in opts || 'includeDeleted' in opts) {
+			return getManyDocumentsQueryKey(opts)
+		}
+		return getDocumentsQueryKey(opts)
+	},
+	'/projects/:projectId/:docType/:docId': getDocumentByDocIdQueryKey,
+	'/projects/:projectId/:docType/:versionId': getDocumentByVersionIdQueryKey,
+} as const
+
+/**
+ * Provides a function that invalidates a specified read when called.
+ *
+ * @example
+ * ```tsx
+ * function App() {
+ *   const invalidateRead = useInvalidateRead()
+ *
+ *   return (
+ *     <button
+ *       onClick={() => {
+ *         // Invalidate all reads!
+ *         invalidateRead('/', undefined)
+ *       }}
+ *     >
+ *       Invalidate everything!
+ *     </button>
+ *   )
+ * }
+ * ```
+ */
+export function useInvalidateRead(): <
+	Path extends keyof typeof PATH_TO_QUERY_KEY_FACTORY,
+>(
+	path: Path,
+	params: Parameters<(typeof PATH_TO_QUERY_KEY_FACTORY)[Path]>[0],
+	invalidationOpts?: {
+		exact: boolean
+	},
+) => Promise<void> {
+	const queryClient = useQueryClient()
+
+	return (path, pathParams, invalidationOpts) => {
+		return queryClient.invalidateQueries({
+			exact: invalidationOpts?.exact,
+			queryKey: PATH_TO_QUERY_KEY_FACTORY[path](
+				// @ts-expect-error TS not capable enough to get this right
+				pathParams,
+			),
+		})
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export {
 	useSingleDocByVersionId,
 	useUpdateDocument,
 } from './hooks/documents.js'
+export { useInvalidateRead } from './hooks/invalidation.js'
 export {
 	useAcceptInvite,
 	useRejectInvite,
@@ -43,31 +44,7 @@ export {
 	getIsArchiveDeviceQueryKey,
 } from './lib/react-query/client.js'
 export {
-	getDocumentByDocIdQueryKey,
-	getDocumentByVersionIdQueryKey,
-	getDocumentsQueryKey,
-	getManyDocumentsQueryKey,
 	type WriteableDocument,
 	type WriteableDocumentType,
 	type WriteableValue,
-} from './lib/react-query/documents.js'
-export {
-	getInvitesQueryKey,
-	getPendingInvitesQueryKey,
-} from './lib/react-query/invites.js'
-export {
-	getMapsQueryKey,
-	getStyleJsonUrlQueryKey,
-} from './lib/react-query/maps.js'
-export {
-	getAttachmentUrlQueryKey,
-	getDocumentCreatedByQueryKey,
-	getIconUrlQueryKey,
-	getMemberByIdQueryKey,
-	getMembersQueryKey,
-	getProjectByIdQueryKey,
-	getProjectRoleQueryKey,
-	getProjectSettingsQueryKey,
-	getProjectsQueryKey,
-} from './lib/react-query/projects.js'
-export { ROOT_QUERY_KEY } from './lib/react-query/shared.js'
+} from './lib/types.js'

--- a/src/lib/react-query/documents.ts
+++ b/src/lib/react-query/documents.ts
@@ -1,32 +1,20 @@
 import type { MapeoProjectApi } from '@comapeo/ipc' with { 'resolution-mode': 'import' }
-import type {
-	MapeoDoc,
-	MapeoValue,
-} from '@comapeo/schema' with { 'resolution-mode': 'import' }
 import {
 	queryOptions,
 	type QueryClient,
 	type UseMutationOptions,
 } from '@tanstack/react-query'
 
+import type {
+	WriteableDocument,
+	WriteableDocumentType,
+	WriteableValue,
+} from '../types.js' with { 'resolution-mode': 'import' }
 import {
 	baseMutationOptions,
 	baseQueryOptions,
 	ROOT_QUERY_KEY,
 } from './shared.js'
-
-export type WriteableDocumentType = Extract<
-	MapeoDoc['schemaName'],
-	'field' | 'observation' | 'preset' | 'track' | 'remoteDetectionAlert'
->
-export type WriteableValue<D extends WriteableDocumentType> = Extract<
-	MapeoValue,
-	{ schemaName: D }
->
-export type WriteableDocument<D extends WriteableDocumentType> = Extract<
-	MapeoDoc,
-	{ schemaName: D }
->
 
 export function getDocumentsQueryKey<D extends WriteableDocumentType>({
 	projectId,

--- a/src/lib/react-query/maps.ts
+++ b/src/lib/react-query/maps.ts
@@ -11,7 +11,7 @@ export function getStyleJsonUrlQueryKey({
 	refreshToken,
 }: {
 	refreshToken?: string
-}) {
+} = {}) {
 	return [ROOT_QUERY_KEY, 'maps', 'stylejson_url', { refreshToken }] as const
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,19 @@
+import type {
+	MapeoDoc,
+	MapeoValue,
+} from '@comapeo/schema' with { 'resolution-mode': 'import' }
+
+export type WriteableDocumentType = Extract<
+	MapeoDoc['schemaName'],
+	'field' | 'observation' | 'preset' | 'track' | 'remoteDetectionAlert'
+>
+export type WriteableValue<D extends WriteableDocumentType> = Extract<
+	MapeoValue,
+	{ schemaName: D }
+>
+export type WriteableDocument<D extends WriteableDocumentType> = Extract<
+	MapeoDoc,
+	{ schemaName: D }
+>
+
+export {}

--- a/test/hooks/invalidation.test.tsx
+++ b/test/hooks/invalidation.test.tsx
@@ -1,0 +1,98 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook } from '@testing-library/react'
+import { assert, test, vi } from 'vitest'
+
+import { PATH_TO_QUERY_KEY_FACTORY } from '../../src/hooks/invalidation.js'
+import { useInvalidateRead } from '../../src/index.js'
+
+test('useInvalidateRead()', async () => {
+	const queryClient = new QueryClient()
+
+	const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+	const invalidateReadHook = renderHook(() => useInvalidateRead(), {
+		wrapper: ({ children }) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		),
+	})
+
+	const fixtures = [
+		['/', undefined],
+		['/maps', undefined],
+		['/maps/styleJsonUrl', undefined],
+		['/invites', undefined],
+		['/invites/pending', undefined],
+		['/client', undefined],
+		['/client/deviceInfo', undefined],
+		['/client/isArchiveDevice', undefined],
+		['/projects', undefined],
+		['/projects/:projectId', { projectId: 'abc123' }],
+		['/projects/:projectId/settings', { projectId: 'project_1' }],
+		['/projects/:projectId/role', { projectId: 'project_1' }],
+		['/projects/:projectId/members', { projectId: 'project_1' }],
+		[
+			'/projects/:projectId/members/:deviceId',
+			{ projectId: 'project_1', deviceId: 'device_a' },
+		],
+		[
+			'/projects/:projectId/icons/:iconId',
+			{ projectId: 'project_1', iconId: 'icon_a' },
+		],
+		[
+			'/projects/:projectId/documentCreatedBy/:originalVersionId',
+			{ projectId: 'project_1', originalVersionId: 'version_a' },
+		],
+		[
+			'/projects/:projectId/attachments/:blobId',
+			{ projectId: 'project_1', blobId: {} },
+		],
+		[
+			'/projects/:projectId/:docType',
+			{ projectId: 'project_1', docType: 'observation' },
+		],
+		[
+			'/projects/:projectId/:docType/:docId',
+			{ projectId: 'project_1', docType: 'observation', docId: 'doc_a' },
+		],
+		[
+			'/projects/:projectId/:docType/:versionId',
+			{ projectId: 'project_1', docType: 'observation', docId: 'version_a' },
+		],
+	] as const
+
+	assert.sameMembers(
+		fixtures.map((v) => {
+			return v[0]
+		}),
+		Object.keys(PATH_TO_QUERY_KEY_FACTORY),
+		'all possible paths are being tested',
+	)
+
+	for (const args of fixtures) {
+		// Without invalidation opts
+		{
+			await invalidateReadHook.result.current(args[0], args[1])
+			const calledWith = invalidateQueriesSpy.mock.lastCall?.[0]
+
+			assert(calledWith)
+			assert(calledWith.exact === undefined)
+			assert.isArray(calledWith.queryKey)
+			assert.isNotEmpty(calledWith.queryKey)
+		}
+
+		// With invalidation opts
+		{
+			const invalidationOpts = { exact: true }
+			await invalidateReadHook.result.current(
+				args[0],
+				args[1],
+				invalidationOpts,
+			)
+			const calledWith = invalidateQueriesSpy.mock.lastCall?.[0]
+			assert(calledWith)
+			assert(calledWith.exact === true)
+			assert.isArray(calledWith.queryKey)
+			assert.isNotEmpty(calledWith.queryKey)
+		}
+	}
+})


### PR DESCRIPTION
Closes #19

proof of concept for how to expose an invalidation helper for reads. i've implemented a `useInvalidateRead()` hook that accepts a "path" (a unix path-like string) and relevant parameters based on the path. This will mostly be used in cases where something external to core is updated and affects core (a good example is the [custom map file import](https://github.com/digidem/comapeo-mobile/blob/45591e581e9248e92dfc4da0b99495531df4a01e/src/frontend/hooks/server/maps.ts#L43-L74)). 

```tsx
function Screen() {
  const importFileMutation = useMutation(...)
  const invalidateRead = useInvalidateRead()
  
  return (
    <Button 
      onPress={() => { 
        importFileMutation.mutate(undefined, {
          onSuccess: () => {
            // Invalidate maps-related queries after file import
            invalidateRead('/maps', undefined)
          }
        })
        
      }}
    >Import file</Button>
  )
}
```

Not totally committed to the API design here. The alternative was to just export 1-to-1 mappings of functions that invalidate a specific read. After considering it for a short while I decided that:

1. Exposing a single hook that can be used as opposed to several was preferable. There's an implicit dependency on accessing a query client in order to actually do the invalidation, so exposing non-hook functions isn't an option since we don't want the usage to require explicitly passing in the query client as a param.

2. Given (1) entails exposing a single hook, having the path-like argument is super helpful as it makes it easier to visualize and understand the cascading nature of invalidations. The autocompletion support feels better than having literal string names that are mapped to each kind of read (e.g. `invalidateRead('allProjects')`, `invalidateRead('singleProject', ...)`, `invalidateRead('maps')`, etc). If you're familiar with various router apis that support interpolated params, it's quite familiar to use.

TODO:

- [ ] finalize API
- [ ] write tests