### PR TITLE
[WIP] fix: add invite hooks

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,8 @@ import { fileURLToPath } from 'node:url'
 import { includeIgnoreFile } from '@eslint/compat'
 import js from '@eslint/js'
 import pluginQuery from '@tanstack/eslint-plugin-query'
+// @ts-expect-error - no type defs
+import pluginReactHooks from 'eslint-plugin-react-hooks'
 import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
@@ -23,6 +25,9 @@ export default tseslint.config(
 	{
 		name: 'typescript',
 		extends: tseslint.configs.recommended,
+		plugins: {
+			'react-hooks': pluginReactHooks,
+		},
 		rules: {
 			'@typescript-eslint/array-type': ['warn', { default: 'generic' }],
 			// Allow unused vars if prefixed with `_` (https://typescript-eslint.io/rules/no-unused-vars/)
@@ -38,6 +43,8 @@ export default tseslint.config(
 					ignoreRestSiblings: true,
 				},
 			],
+			'react-hooks/rules-of-hooks': 'error',
+			'react-hooks/exhaustive-deps': 'error',
 		},
 	},
 	...pluginQuery.configs['flat/recommended'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
 				"@types/react": "19.0.8",
 				"@types/react-dom": "19.0.3",
 				"eslint": "9.19.0",
+				"eslint-plugin-react-hooks": "^5.1.0",
 				"fastify": "4.29.0",
 				"globals": "15.14.0",
 				"husky": "9.1.7",
@@ -4476,6 +4477,19 @@
 				"jiti": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/eslint-plugin-react-hooks": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0.tgz",
+			"integrity": "sha512-mpJRtPgHN2tNAvZ35AMfqeB3Xqeo273QxrHJsbBEPWODRM4r0yB6jfoROqKEYrOn27UtRPpcpHc2UqyBSuUNTw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
 			}
 		},
 		"node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
 		"@types/react": "19.0.8",
 		"@types/react-dom": "19.0.3",
 		"eslint": "9.19.0",
+		"eslint-plugin-react-hooks": "^5.1.0",
 		"fastify": "4.29.0",
 		"globals": "15.14.0",
 		"husky": "9.1.7",

--- a/src/contexts/ClientApi.ts
+++ b/src/contexts/ClientApi.ts
@@ -1,7 +1,14 @@
 import type { MapeoClientApi } from '@comapeo/ipc' with { 'resolution-mode': 'import' }
-import { createContext, createElement, type ReactNode } from 'react'
+import { createContext, createElement, useRef, type ReactNode } from 'react'
 
-export const ClientApiContext = createContext<MapeoClientApi | null>(null)
+import { PendingInviteStore } from '../lib/pending-invite-store.js'
+
+type ClientApiContextValue = {
+	clientApi: MapeoClientApi
+	pendingInviteStore: PendingInviteStore
+} | null
+
+export const ClientApiContext = createContext<ClientApiContextValue>(null)
 
 /**
  * Create a context provider that holds a CoMapeo API client instance.
@@ -17,9 +24,20 @@ export function ClientApiProvider({
 	children: ReactNode
 	clientApi: MapeoClientApi
 }) {
+	const valueRef = useRef<ClientApiContextValue>(null)
+	if (valueRef.current === null) {
+		// This is ok to do, see https://web.archive.org/web/20250128072444/https://react.dev/reference/react/useRef#expand
+		valueRef.current = {
+			clientApi,
+			pendingInviteStore: new PendingInviteStore(clientApi),
+		}
+	}
+	if (valueRef.current.clientApi !== clientApi) {
+		throw new Error('Client API instance must be stable')
+	}
 	return createElement(
 		ClientApiContext.Provider,
-		{ value: clientApi },
+		{ value: valueRef.current },
 		children,
 	)
 }

--- a/src/hooks/client.ts
+++ b/src/hooks/client.ts
@@ -39,15 +39,15 @@ import {
  *
  */
 export function useClientApi() {
-	const clientApi = useContext(ClientApiContext)
+	const contextValue = useContext(ClientApiContext)
 
-	if (!clientApi) {
+	if (!contextValue) {
 		throw new Error(
 			'No client API set. Make sure you set up the ClientApiContext provider properly',
 		)
 	}
 
-	return clientApi
+	return contextValue.clientApi
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { ClientApiContext, ClientApiProvider } from './contexts/ClientApi.js'
+export { ClientApiProvider } from './contexts/ClientApi.js'
 export {
 	useClientApi,
 	useIsArchiveDevice,
@@ -15,6 +15,9 @@ export {
 	useUpdateDocument,
 } from './hooks/documents.js'
 export {
+	usePendingInviteStore,
+	usePendingInviteListener,
+	useCancelledInviteListener,
 	useAcceptInvite,
 	useRejectInvite,
 	useRequestCancelInvite,

--- a/src/lib/pending-invite-store.ts
+++ b/src/lib/pending-invite-store.ts
@@ -1,0 +1,121 @@
+import type { Invite } from '@comapeo/core/dist/invite-api.js'
+import type { MapeoClientApi } from '@comapeo/ipc'
+
+export class PendingInviteStore {
+	#api
+	#listeners = new Set<() => void>()
+	#isSubscribedInternal = false
+	#oldestPendingInvite: Invite | null = null
+	#pendingInvites = new Map<string, Invite>()
+	#abortController: AbortController | null = null
+
+	/////// Start of bound methods
+
+	#handleInviteReceived = (invite: Invite) => {
+		this.#pendingInvites.set(invite.inviteId, invite)
+		const pending = this.#oldestPendingInvite
+		const shouldUpdatePending =
+			pending === null || getOldestInvite([pending, invite]) !== pending
+		if (shouldUpdatePending) {
+			this.#oldestPendingInvite = invite
+			this.#notifyListeners()
+		}
+	}
+
+	#handleInviteRemoved = (invite: Invite) => {
+		this.#pendingInvites.delete(invite.inviteId)
+		if (invite.inviteId !== this.#oldestPendingInvite?.inviteId) {
+			return
+		}
+		const pending = [...this.#pendingInvites.values()]
+		if (isNonEmptyArray(pending)) {
+			this.#oldestPendingInvite = getOldestInvite(pending)
+		} else {
+			this.#oldestPendingInvite = null
+		}
+		this.#notifyListeners()
+	}
+
+	subscribe = (listener: () => void) => {
+		this.#listeners.add(listener)
+		if (!this.#isSubscribedInternal) this.#startSubscription()
+		return () => {
+			this.#listeners.delete(listener)
+			if (this.#listeners.size === 0) this.#stopSubscription()
+		}
+	}
+
+	getSnapshot = () => {
+		if (!this.#isSubscribedInternal) {
+			throw new Error(
+				'At least one listener must be subscribed to get the snapshot',
+			)
+		}
+		return this.#oldestPendingInvite
+	}
+
+	/////// End of bound methods
+
+	constructor(mapeoClientApi: MapeoClientApi) {
+		this.#api = mapeoClientApi
+	}
+
+	#startSubscription() {
+		this.#isSubscribedInternal = true
+		this.#pendingInvites.clear()
+		this.#oldestPendingInvite = null
+		this.#notifyListeners()
+		this.#abortController = new AbortController()
+		const { signal } = this.#abortController
+		this.#api.invite.on('invite-received', this.#handleInviteReceived)
+		this.#api.invite.on('invite-removed', this.#handleInviteRemoved)
+		this.#api.invite
+			.getPending()
+			.then((invites) => {
+				if (signal.aborted) return
+				for (const invite of invites) {
+					this.#pendingInvites.set(invite.inviteId, invite)
+				}
+			})
+			.catch(noop)
+	}
+
+	#stopSubscription() {
+		this.#isSubscribedInternal = false
+		this.#abortController?.abort()
+		this.#abortController = null
+		this.#api.invite.off('invite-received', this.#handleInviteReceived)
+		this.#api.invite.off('invite-removed', this.#handleInviteRemoved)
+	}
+
+	#notifyListeners() {
+		for (const listener of this.#listeners) {
+			listener()
+		}
+	}
+}
+
+type NonEmptyArray<T> = [T, ...Array<T>]
+
+function isNonEmptyArray<T>(arr: Array<T>): arr is NonEmptyArray<T> {
+	return arr.length > 0
+}
+
+function getOldestInvite(invites: NonEmptyArray<Invite>): Invite {
+	let oldest: Invite = invites[0]
+	for (const invite of invites) {
+		if (oldest === invite) continue
+		if (invite.receivedAt < oldest.receivedAt) {
+			oldest = invite
+		} else if (
+			// If two invites are received at the same time, deterministically select one based on inviteId
+			invite.receivedAt === oldest.receivedAt &&
+			invite.inviteId < oldest.inviteId
+		) {
+			oldest = invite
+		}
+	}
+	return oldest
+}
+
+function noop() {}


### PR DESCRIPTION
This is an initial attempt at implementing invite hooks, fixing #8.

NB: this PR removes the export of `<ClientApiContext>` which should now be considered an implementation detail - I can't see a reason for using this outside of this module.

The implementation adds a `PendingInviteStore` which provides a stable "oldest pending invite" and the option to subscribe to when this changes, however subscribing manually should be discouraged, and we could perhaps only return the `getPendingInvite()` method from the store.

The proposed usage is:

```js
import {
  usePendingInviteStore,
  usePendingInviteListener,
  useCancelledInviteListener
} from '@comapeo/core-react'

const RootNavigationComponent = () => {
  const {
    canShowNewInvite,
    screenIsOpenForInvite,
    showNewInvite,
    showCanceledInvite
  } = useInviteNavigationHelpers() // Some hook to wrap navigation library used

  const pendingInviteStore = usePendingInviteStore()

  usePendingInviteListener(invite => {
    if (!canShowNewInvite()) return
    showNewInvite(invite)
  })

  useCancelledInviateListener(invite => {
    if (screenIsOpenForInvite(invite.inviteId)) {
      showCanceledInvite(invite)
    }
  })

  useNavigationScreenChangedListener(screenName => {
    if (!canShowNewInvite()) return
    const invite = pendingInviteStore.getSnapshot()
    if (invite) showNewInvite(invite)
  })

  // ...rest of component
}
```