### PR TITLE
feat: introduce initial sync hooks

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -20,6 +20,10 @@
 - [useImportProjectConfig](#useimportprojectconfig)
 - [useUpdateProjectSettings](#useupdateprojectsettings)
 - [useCreateBlob](#usecreateblob)
+- [useSyncState](#usesyncstate)
+- [useDataSyncProgress](#usedatasyncprogress)
+- [useStartSync](#usestartsync)
+- [useStopSync](#usestopsync)
 - [useSingleDocByDocId](#usesingledocbydocid)
 - [useSingleDocByVersionId](#usesingledocbyversionid)
 - [useManyDocs](#usemanydocs)
@@ -433,6 +437,58 @@ Parameters:
 
 * `opts.projectId`: Public project ID of project to apply to changes to.
 
+
+### useSyncState
+
+Hook to subscribe to the current sync state.
+
+Creates a global singleton for each project, to minimize traffic over IPC -
+this hook can safely be used in more than one place without attaching
+additional listeners across the IPC channel.
+
+| Function | Type |
+| ---------- | ---------- |
+| `useSyncState` | `({ projectId, }: { projectId: string; }) => State or null` |
+
+Parameters:
+
+* `opts.projectId`: Project public ID
+
+
+Examples:
+
+```ts
+function Example() {
+    const syncState = useSyncState({ projectId });
+
+    if (!syncState) {
+        // Sync information hasn't been loaded yet
+    }
+
+    // Actual info about sync state is available...
+}
+```
+
+
+### useDataSyncProgress
+
+Provides the progress of data sync for sync-enabled connected peers
+
+| Function | Type |
+| ---------- | ---------- |
+| `useDataSyncProgress` | `({ projectId, }: { projectId: string; }) => number or null` |
+
+### useStartSync
+
+| Function | Type |
+| ---------- | ---------- |
+| `useStartSync` | `({ projectId }: { projectId: string; }) => { mutate: UseMutateFunction<void, Error, { autostopDataSyncAfter: number or null; } or undefined, unknown>; reset: () => void; status: "pending" or ... 2 more ... or "idle"; }` |
+
+### useStopSync
+
+| Function | Type |
+| ---------- | ---------- |
+| `useStopSync` | `({ projectId }: { projectId: string; }) => { mutate: UseMutateFunction<void, Error, void, unknown>; reset: () => void; status: "pending" or "error" or "success" or "idle"; }` |
 
 ### useSingleDocByDocId
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export {
 	useAttachmentUrl,
 	useCreateBlob,
 	useCreateProject,
+	useDataSyncProgress,
 	useDocumentCreatedBy,
 	useIconUrl,
 	useImportProjectConfig,
@@ -35,8 +36,12 @@ export {
 	useProjectSettings,
 	useSingleMember,
 	useSingleProject,
+	useStartSync,
+	useStopSync,
+	useSyncState,
 	useUpdateProjectSettings,
 } from './hooks/projects.js'
+export { type SyncState } from './lib/sync.js'
 export {
 	type WriteableDocument,
 	type WriteableDocumentType,

--- a/src/lib/react-query/projects.ts
+++ b/src/lib/react-query/projects.ts
@@ -413,3 +413,35 @@ export function createBlobMutationOptions({
 		}
 	>
 }
+
+export function startSyncMutationOptions({
+	projectApi,
+}: {
+	projectApi: MapeoProjectApi
+}) {
+	return {
+		...baseMutationOptions(),
+		mutationFn: async (opts) => {
+			// Have to avoid passing `undefined` explicitly
+			// See https://github.com/digidem/rpc-reflector/issues/21
+			return opts ? projectApi.$sync.start(opts) : projectApi.$sync.start()
+		},
+	} satisfies UseMutationOptions<
+		void,
+		Error,
+		{ autostopDataSyncAfter: number | null } | undefined
+	>
+}
+
+export function stopSyncMutationOptions({
+	projectApi,
+}: {
+	projectApi: MapeoProjectApi
+}) {
+	return {
+		...baseMutationOptions(),
+		mutationFn: async () => {
+			return projectApi.$sync.stop()
+		},
+	} satisfies UseMutationOptions<void, Error, void>
+}

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -1,0 +1,144 @@
+import type { MapeoProjectApi } from '@comapeo/ipc' with { 'resolution-mode': 'import' }
+
+export type SyncState = Awaited<
+	ReturnType<MapeoProjectApi['$sync']['getState']>
+>
+
+export function getDataSyncCountForDevice(
+	syncStateForDevice: SyncState['remoteDeviceSyncState'][string],
+) {
+	const { data } = syncStateForDevice
+	return data.want + data.wanted
+}
+
+export class SyncStore {
+	#project: MapeoProjectApi
+
+	#listeners = new Set<() => void>()
+	#isSubscribedInternal = false
+	#error: Error | null = null
+	#state: SyncState | null = null
+
+	// Used for calculating sync progress
+	#perDeviceMaxSyncCount = new Map<string, number>()
+
+	constructor(project: MapeoProjectApi) {
+		this.#project = project
+	}
+
+	subscribe = (listener: () => void) => {
+		this.#listeners.add(listener)
+		if (!this.#isSubscribedInternal) this.#startSubscription()
+		return () => {
+			this.#listeners.delete(listener)
+			if (this.#listeners.size === 0) this.#stopSubscription()
+		}
+	}
+
+	getStateSnapshot = () => {
+		if (this.#error) throw this.#error
+		return this.#state
+	}
+
+	getDataProgressSnapshot = () => {
+		if (this.#state === null) {
+			return null
+		}
+
+		let currentSyncCount = 0
+		let totalMaxSyncCount = 0
+		let otherEnabledDevicesExist = false
+
+		for (const [deviceId, deviceSyncState] of Object.entries(
+			this.#state.remoteDeviceSyncState,
+		)) {
+			if (deviceSyncState.data.isSyncEnabled) {
+				otherEnabledDevicesExist = true
+			} else {
+				continue
+			}
+
+			const existingMaxCount = this.#perDeviceMaxSyncCount.get(deviceId)
+
+			if (typeof existingMaxCount === 'number' && existingMaxCount > 0) {
+				currentSyncCount = getDataSyncCountForDevice(deviceSyncState)
+				totalMaxSyncCount += existingMaxCount
+			}
+		}
+
+		if (!otherEnabledDevicesExist) {
+			return null
+		}
+
+		if (totalMaxSyncCount === 0) {
+			return 1
+		}
+
+		const ratio = (totalMaxSyncCount - currentSyncCount) / totalMaxSyncCount
+
+		if (ratio <= 0) return 0
+		if (ratio >= 1) return 1
+
+		return clamp(ratio, 0.01, 0.99)
+	}
+
+	#notifyListeners() {
+		for (const listener of this.#listeners) {
+			listener()
+		}
+	}
+
+	#onSyncState = (state: SyncState) => {
+		const dataSyncWasEnabled = this.#state
+			? this.#state.data.isSyncEnabled
+			: false
+
+		// Reset map keeping track of counts used for progress if data sync is toggled
+		if (dataSyncWasEnabled !== state.data.isSyncEnabled) {
+			this.#perDeviceMaxSyncCount.clear()
+		} else {
+			// Remove devices from #perDeviceMaxSyncCount that are no longer found in the new sync state
+			for (const deviceId of this.#perDeviceMaxSyncCount.keys()) {
+				if (!Object.hasOwn(state.remoteDeviceSyncState, deviceId)) {
+					this.#perDeviceMaxSyncCount.delete(deviceId)
+				}
+			}
+		}
+
+		for (const [deviceId, stateForDevice] of Object.entries(
+			state.remoteDeviceSyncState,
+		)) {
+			const existingCount = this.#perDeviceMaxSyncCount.get(deviceId)
+			const newCount = getDataSyncCountForDevice(stateForDevice)
+
+			if (existingCount === undefined || existingCount < newCount) {
+				this.#perDeviceMaxSyncCount.set(deviceId, newCount)
+			}
+		}
+
+		this.#state = state
+		this.#error = null
+		this.#notifyListeners()
+	}
+
+	#startSubscription = () => {
+		this.#project.$sync.on('sync-state', this.#onSyncState)
+		this.#isSubscribedInternal = true
+		this.#project.$sync
+			.getState()
+			.then(this.#onSyncState)
+			.catch((e) => {
+				this.#error = e
+				this.#notifyListeners()
+			})
+	}
+
+	#stopSubscription = () => {
+		this.#isSubscribedInternal = false
+		this.#project.$sync.off('sync-state', this.#onSyncState)
+	}
+}
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.max(min, Math.min(value, max))
+}

--- a/test/hooks/projects.test.tsx
+++ b/test/hooks/projects.test.tsx
@@ -1,0 +1,184 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { JSXElementConstructor, ReactNode } from 'react'
+import { assert, describe, test } from 'vitest'
+
+import {
+	useDataSyncProgress,
+	useStartSync,
+	useStopSync,
+} from '../../src/hooks/projects.js'
+import {
+	useCreateProject,
+	useSingleProject,
+	useSyncState,
+} from '../../src/index.js'
+import { setupCoreIpc } from '../helpers/ipc.js'
+import { createClientApiWrapper } from '../helpers/react.js'
+
+describe('sync', () => {
+	async function initializeProject({
+		name,
+		wrapper,
+	}: {
+		name: string
+		wrapper?: JSXElementConstructor<{ children: ReactNode }>
+	}): Promise<string> {
+		const createProjectHook = renderHook(() => useCreateProject(), { wrapper })
+
+		let projectId: string | undefined
+
+		const createProjectPromise = new Promise<void>((res, rej) => {
+			createProjectHook.result.current.mutate(
+				{ name },
+				{
+					onError: rej,
+					onSuccess: (result) => {
+						projectId = result
+						res()
+					},
+				},
+			)
+		})
+
+		await waitFor(() => {
+			return createProjectPromise
+		})
+
+		assert(projectId)
+
+		const project1 = renderHook(
+			({ projectId }) => useSingleProject({ projectId }),
+			{ wrapper, initialProps: { projectId } },
+		)
+
+		await waitFor(() => {
+			return project1.result.current !== null
+		})
+
+		return projectId
+	}
+
+	test('sync state (no peers)', async (t) => {
+		const { client, cleanup } = setupCoreIpc()
+
+		t.onTestFinished(() => {
+			return cleanup()
+		})
+
+		const queryClient = new QueryClient()
+
+		const wrapper = createClientApiWrapper({ clientApi: client, queryClient })
+
+		const project1Id = await initializeProject({ name: 'project_1', wrapper })
+
+		// ---------- Actual tests ----------
+
+		const syncStateHook = renderHook(
+			({ projectId }) => useSyncState({ projectId }),
+			{ wrapper, initialProps: { projectId: project1Id } },
+		)
+
+		// 1. Initial hook value
+		assert(
+			syncStateHook.result.current === null,
+			'initial sync state hook value',
+		)
+
+		await waitFor(() => {
+			return syncStateHook.result.current !== null
+		})
+
+		// 2. After sync state is initially calculated when project sync has not been enabled
+		assert.deepStrictEqual(
+			syncStateHook.result.current,
+			{
+				data: { isSyncEnabled: false },
+				initial: { isSyncEnabled: true },
+				remoteDeviceSyncState: {},
+			},
+			'sync state when initialized',
+		)
+
+		// 3. After project enables sync
+		const startSyncHook = renderHook(
+			({ projectId }) => useStartSync({ projectId }),
+			{ wrapper, initialProps: { projectId: project1Id } },
+		)
+
+		act(() => {
+			startSyncHook.result.current.mutate(undefined)
+		})
+
+		// TODO: Ideally wait for pending status first
+		await waitFor(() => {
+			assert(startSyncHook.result.current.status === 'success')
+		})
+
+		assert.deepStrictEqual(
+			syncStateHook.result.current,
+			{
+				data: { isSyncEnabled: true },
+				initial: { isSyncEnabled: true },
+				remoteDeviceSyncState: {},
+			},
+			'sync state after sync is enabled',
+		)
+
+		// 3. After project disables sync
+		const stopSyncHook = renderHook(
+			({ projectId }) => useStopSync({ projectId }),
+			{ wrapper, initialProps: { projectId: project1Id } },
+		)
+
+		act(() => {
+			stopSyncHook.result.current.mutate(undefined)
+		})
+
+		// TODO: Ideally wait for pending status first
+		await waitFor(() => {
+			assert(stopSyncHook.result.current.status === 'success')
+		})
+
+		assert.deepStrictEqual(
+			syncStateHook.result.current,
+			{
+				data: { isSyncEnabled: false },
+				initial: { isSyncEnabled: true },
+				remoteDeviceSyncState: {},
+			},
+			'sync state after sync is disabled',
+		)
+	})
+
+	test('data sync progress (no peers)', async (t) => {
+		const { client, cleanup } = setupCoreIpc()
+
+		t.onTestFinished(() => {
+			return cleanup()
+		})
+
+		const queryClient = new QueryClient()
+
+		const wrapper = createClientApiWrapper({ clientApi: client, queryClient })
+
+		const project1Id = await initializeProject({ name: 'project_1', wrapper })
+
+		// ---------- Actual tests ----------
+
+		// 1. Initial hook value
+		const dataSyncProgressHook = renderHook(
+			({ projectId }) => useDataSyncProgress({ projectId }),
+			{ wrapper, initialProps: { projectId: project1Id } },
+		)
+
+		assert(
+			dataSyncProgressHook.result.current === null,
+			'initial hook value is null',
+		)
+
+		// 2. TODO: After project enables sync
+
+		// 3. TODO: After disables sync
+	})
+})


### PR DESCRIPTION
Closes #9 

Exposes 4 hooks:

- Read
  - `useSyncState()`: get calculated "sync state". directly ported from comapeo-mobile
  - `useDataSyncProgress()`: gets calculated progress of `data` sync. directly ported from comapeo-mobile
  
- Write
  - `useStartSync()`: enables sync for a project
  - `useStopSync()`: disables sync for a project
  
Have the beginnings of some tests but definitely not exhaustive. Open to suggestions on how to approach.