### PR TITLE
fix: use explicit return type for ClientApiProvider

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -38,7 +38,7 @@ Create a context provider that holds a CoMapeo API client instance.
 
 | Function | Type |
 | ---------- | ---------- |
-| `ClientApiProvider` | `({ children, clientApi, }: { children: ReactNode; clientApi: MapeoClientApi; }) => FunctionComponentElement<ProviderProps<MapeoClientApi or null>>` |
+| `ClientApiProvider` | `({ children, clientApi, }: { children: ReactNode; clientApi: MapeoClientApi; }) => Element` |
 
 Parameters:
 
@@ -427,7 +427,7 @@ Create a blob for a project.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useCreateBlob` | `({ projectId }: { projectId: string; }) => { mutate: UseMutateFunction<{ driveId: string; name: string; type: "audio" or "video" or "photo"; hash: string; }, Error, { original: string; preview?: string or undefined; thumbnail?: string or undefined; metadata: Metadata; }, unknown>; reset: () => void; status: "pending" or ...` |
+| `useCreateBlob` | `({ projectId }: { projectId: string; }) => { mutate: UseMutateFunction<{ driveId: string; name: string; type: "photo" or "audio" or "video"; hash: string; }, Error, { original: string; preview?: string or undefined; thumbnail?: string or undefined; metadata: Metadata; }, unknown>; reset: () => void; status: "pending" or ...` |
 
 Parameters:
 

--- a/src/contexts/ClientApi.ts
+++ b/src/contexts/ClientApi.ts
@@ -1,14 +1,14 @@
 import type { MapeoClientApi } from '@comapeo/ipc' with { 'resolution-mode': 'import' }
-import { createContext, createElement, type ReactNode } from 'react'
+import { createContext, createElement, type JSX, type ReactNode } from 'react'
 
 export const ClientApiContext = createContext<MapeoClientApi | null>(null)
 
 /**
  * Create a context provider that holds a CoMapeo API client instance.
  *
- * @param opts
- * @param {ReactNode} opts.children React children node
- * @param {MapeoClientApi} opts.clientApi Client API instance
+ * @param opts.children React children node
+ * @param opts.clientApi Client API instance
+ *
  */
 export function ClientApiProvider({
 	children,
@@ -16,7 +16,7 @@ export function ClientApiProvider({
 }: {
 	children: ReactNode
 	clientApi: MapeoClientApi
-}) {
+}): JSX.Element {
 	return createElement(
 		ClientApiContext.Provider,
 		{ value: clientApi },


### PR DESCRIPTION
without this, the return type resolves to `React.FunctionComponentElement`, which is a deprecated type.