### PR TITLE
feat: expose mutateAsync method for write hooks

### DIFF
--- a/src/hooks/client.ts
+++ b/src/hooks/client.ts
@@ -97,13 +97,13 @@ export function useSetOwnDeviceInfo() {
 	const queryClient = useQueryClient()
 	const clientApi = useClientApi()
 
-	const { error, mutate, reset, status } = useMutation(
+	const { error, mutate, mutateAsync, reset, status } = useMutation(
 		setOwnDeviceInfoMutationOptions({ clientApi, queryClient }),
 	)
 
 	return status === 'error'
-		? { error, mutate, reset, status }
-		: { error: null, mutate, reset, status }
+		? { error, mutate, mutateAsync, reset, status }
+		: { error: null, mutate, mutateAsync, reset, status }
 }
 
 /**
@@ -113,11 +113,11 @@ export function useSetIsArchiveDevice() {
 	const queryClient = useQueryClient()
 	const clientApi = useClientApi()
 
-	const { error, mutate, status, reset } = useMutation(
+	const { error, mutate, mutateAsync, status, reset } = useMutation(
 		setIsArchiveDeviceMutationOptions({ clientApi, queryClient }),
 	)
 
 	return status === 'error'
-		? { error, mutate, reset, status }
-		: { error: null, mutate, reset, status }
+		? { error, mutate, mutateAsync, reset, status }
+		: { error: null, mutate, mutateAsync, reset, status }
 }

--- a/src/hooks/documents.ts
+++ b/src/hooks/documents.ts
@@ -213,7 +213,7 @@ export function useCreateDocument<D extends WriteableDocumentType>({
 	const queryClient = useQueryClient()
 	const { data: projectApi } = useSingleProject({ projectId })
 
-	const { error, mutate, reset, status } = useMutation(
+	const { error, mutate, mutateAsync, reset, status } = useMutation(
 		createDocumentMutationOptions({
 			docType,
 			projectApi,
@@ -223,8 +223,8 @@ export function useCreateDocument<D extends WriteableDocumentType>({
 	)
 
 	return status === 'error'
-		? { error, mutate, reset, status }
-		: { error: null, mutate, reset, status }
+		? { error, mutate, mutateAsync, reset, status }
+		: { error: null, mutate, mutateAsync, reset, status }
 }
 
 /**
@@ -243,7 +243,7 @@ export function useUpdateDocument<D extends WriteableDocumentType>({
 	const queryClient = useQueryClient()
 	const { data: projectApi } = useSingleProject({ projectId })
 
-	const { error, mutate, reset, status } = useMutation(
+	const { error, mutate, mutateAsync, reset, status } = useMutation(
 		updateDocumentMutationOptions({
 			docType,
 			projectApi,
@@ -253,8 +253,8 @@ export function useUpdateDocument<D extends WriteableDocumentType>({
 	)
 
 	return status === 'error'
-		? { error, mutate, reset, status }
-		: { error: null, mutate, reset, status }
+		? { error, mutate, mutateAsync, reset, status }
+		: { error: null, mutate, mutateAsync, reset, status }
 }
 
 /**
@@ -273,7 +273,7 @@ export function useDeleteDocument<D extends WriteableDocumentType>({
 	const queryClient = useQueryClient()
 	const { data: projectApi } = useSingleProject({ projectId })
 
-	const { error, mutate, reset, status } = useMutation(
+	const { error, mutate, mutateAsync, reset, status } = useMutation(
 		deleteDocumentMutationOptions({
 			docType,
 			projectApi,
@@ -283,6 +283,6 @@ export function useDeleteDocument<D extends WriteableDocumentType>({
 	)
 
 	return status === 'error'
-		? { error, mutate, reset, status }
-		: { error: null, mutate, reset, status }
+		? { error, mutate, mutateAsync, reset, status }
+		: { error: null, mutate, mutateAsync, reset, status }
 }

--- a/src/hooks/invites.ts
+++ b/src/hooks/invites.ts
@@ -16,13 +16,13 @@ export function useAcceptInvite() {
 	const queryClient = useQueryClient()
 	const clientApi = useClientApi()
 
-	const { error, mutate, reset, status } = useMutation(
+	const { error, mutate, mutateAsync, reset, status } = useMutation(
 		acceptInviteMutationOptions({ clientApi, queryClient }),
 	)
 
 	return status === 'error'
-		? { error, mutate, reset, status }
-		: { error: null, mutate, reset, status }
+		? { error, mutate, mutateAsync, reset, status }
+		: { error: null, mutate, mutateAsync, reset, status }
 }
 
 /**
@@ -32,13 +32,13 @@ export function useRejectInvite() {
 	const queryClient = useQueryClient()
 	const clientApi = useClientApi()
 
-	const { error, mutate, reset, status } = useMutation(
+	const { error, mutate, mutateAsync, reset, status } = useMutation(
 		rejectInviteMutationOptions({ clientApi, queryClient }),
 	)
 
 	return status === 'error'
-		? { error, mutate, reset, status }
-		: { error: null, mutate, reset, status }
+		? { error, mutate, mutateAsync, reset, status }
+		: { error: null, mutate, mutateAsync, reset, status }
 }
 
 /**
@@ -50,13 +50,13 @@ export function useSendInvite({ projectId }: { projectId: string }) {
 	const queryClient = useQueryClient()
 	const { data: projectApi } = useSingleProject({ projectId })
 
-	const { error, mutate, reset, status } = useMutation(
+	const { error, mutate, mutateAsync, reset, status } = useMutation(
 		sendInviteMutationOptions({ projectApi, projectId, queryClient }),
 	)
 
 	return status === 'error'
-		? { error, mutate, reset, status }
-		: { error: null, mutate, reset, status }
+		? { error, mutate, mutateAsync, reset, status }
+		: { error: null, mutate, mutateAsync, reset, status }
 }
 
 /**
@@ -68,11 +68,11 @@ export function useRequestCancelInvite({ projectId }: { projectId: string }) {
 	const queryClient = useQueryClient()
 	const { data: projectApi } = useSingleProject({ projectId })
 
-	const { error, mutate, reset, status } = useMutation(
+	const { error, mutate, mutateAsync, reset, status } = useMutation(
 		requestCancelInviteMutationOptions({ projectApi, queryClient }),
 	)
 
 	return status === 'error'
-		? { error, mutate, reset, status }
-		: { error: null, mutate, reset, status }
+		? { error, mutate, mutateAsync, reset, status }
+		: { error: null, mutate, mutateAsync, reset, status }
 }

--- a/src/hooks/projects.ts
+++ b/src/hooks/projects.ts
@@ -373,13 +373,13 @@ export function useAddServerPeer({ projectId }: { projectId: string }) {
 	const queryClient = useQueryClient()
 	const { data: projectApi } = useSingleProject({ projectId })
 
-	const { error, mutate, reset, status } = useMutation(
+	const { error, mutate, mutateAsync, reset, status } = useMutation(
 		addServerPeerMutationOptions({ projectApi, projectId, queryClient }),
 	)
 
 	return status === 'error'
-		? { error, mutate, reset, status }
-		: { error: null, mutate, reset, status }
+		? { error, mutate, mutateAsync, reset, status }
+		: { error: null, mutate, mutateAsync, reset, status }
 }
 
 /**
@@ -389,13 +389,13 @@ export function useCreateProject() {
 	const queryClient = useQueryClient()
 	const clientApi = useClientApi()
 
-	const { error, mutate, reset, status } = useMutation(
+	const { error, mutate, mutateAsync, reset, status } = useMutation(
 		createProjectMutationOptions({ clientApi, queryClient }),
 	)
 
 	return status === 'error'
-		? { error, mutate, reset, status }
-		: { error: null, mutate, reset, status }
+		? { error, mutate, mutateAsync, reset, status }
+		: { error: null, mutate, mutateAsync, reset, status }
 }
 
 /**
@@ -405,13 +405,13 @@ export function useLeaveProject() {
 	const queryClient = useQueryClient()
 	const clientApi = useClientApi()
 
-	const { error, mutate, reset, status } = useMutation(
+	const { error, mutate, mutateAsync, reset, status } = useMutation(
 		leaveProjectMutationOptions({ clientApi, queryClient }),
 	)
 
 	return status === 'error'
-		? { error, mutate, reset, status }
-		: { error: null, mutate, reset, status }
+		? { error, mutate, mutateAsync, reset, status }
+		: { error: null, mutate, mutateAsync, reset, status }
 }
 
 /**
@@ -423,13 +423,13 @@ export function useImportProjectConfig({ projectId }: { projectId: string }) {
 	const queryClient = useQueryClient()
 	const { data: projectApi } = useSingleProject({ projectId })
 
-	const { error, mutate, reset, status } = useMutation(
+	const { error, mutate, mutateAsync, reset, status } = useMutation(
 		importProjectConfigMutationOptions({ queryClient, projectApi, projectId }),
 	)
 
 	return status === 'error'
-		? { error, mutate, reset, status }
-		: { error: null, mutate, reset, status }
+		? { error, mutate, mutateAsync, reset, status }
+		: { error: null, mutate, mutateAsync, reset, status }
 }
 
 /**
@@ -441,13 +441,13 @@ export function useUpdateProjectSettings({ projectId }: { projectId: string }) {
 	const queryClient = useQueryClient()
 	const { data: projectApi } = useSingleProject({ projectId })
 
-	const { error, mutate, reset, status } = useMutation(
+	const { error, mutate, mutateAsync, reset, status } = useMutation(
 		updateProjectSettingsMutationOptions({ projectApi, queryClient }),
 	)
 
 	return status === 'error'
-		? { error, mutate, reset, status }
-		: { error: null, mutate, reset, status }
+		? { error, mutate, mutateAsync, reset, status }
+		: { error: null, mutate, mutateAsync, reset, status }
 }
 
 /**
@@ -458,13 +458,13 @@ export function useUpdateProjectSettings({ projectId }: { projectId: string }) {
 export function useCreateBlob({ projectId }: { projectId: string }) {
 	const { data: projectApi } = useSingleProject({ projectId })
 
-	const { error, mutate, reset, status } = useMutation(
+	const { error, mutate, mutateAsync, reset, status } = useMutation(
 		createBlobMutationOptions({ projectApi }),
 	)
 
 	return status === 'error'
-		? { error, mutate, reset, status }
-		: { error: null, mutate, reset, status }
+		? { error, mutate, mutateAsync, reset, status }
+		: { error: null, mutate, mutateAsync, reset, status }
 }
 
 const PROJECT_SYNC_STORE_MAP = new WeakMap<MapeoProjectApi, SyncStore>()
@@ -533,23 +533,23 @@ export function useDataSyncProgress({
 export function useStartSync({ projectId }: { projectId: string }) {
 	const { data: projectApi } = useSingleProject({ projectId })
 
-	const { mutate, reset, status, error } = useMutation(
+	const { error, mutate, mutateAsync, reset, status } = useMutation(
 		startSyncMutationOptions({ projectApi }),
 	)
 
 	return status === 'error'
-		? { error, mutate, reset, status }
-		: { error: null, mutate, reset, status }
+		? { error, mutate, mutateAsync, reset, status }
+		: { error: null, mutate, mutateAsync, reset, status }
 }
 
 export function useStopSync({ projectId }: { projectId: string }) {
 	const { data: projectApi } = useSingleProject({ projectId })
 
-	const { error, mutate, reset, status } = useMutation(
+	const { error, mutate, mutateAsync, reset, status } = useMutation(
 		stopSyncMutationOptions({ projectApi }),
 	)
 
 	return status === 'error'
-		? { error, mutate, reset, status }
-		: { error: null, mutate, reset, status }
+		? { error, mutate, mutateAsync, reset, status }
+		: { error: null, mutate, mutateAsync, reset, status }
 }


### PR DESCRIPTION
Noticed an issue from https://github.com/digidem/comapeo-mobile/pull/1038 where wrapping the `mutate` method with a promise leads to unexpected behavior. The initial reasoning was to avoid needing to expose React Query's `mutateAsync` in the write hooks and let the consumer do the wrapping themselves if needed. However, it seems that wrapping it (like `new Promise((res ,rej) => mutation.mutate(..., { onError: rej, onSuccess: res }))`) doesn't actually work as expected in some specific cases. This is most notable when trying to do parallel mutations. For example:

```tsx
function MutateExample() {
  const createDocument = useCreateDocument(...)

  const wrapperMutation = useMutation({
    mutationFn: async () => {
      // Some other work before this
      return Promise.all([
        new Promise((res, rej) => createDocument.mutate(..., { onError: rej, onSuccess: res }),
        new Promise((res, rej) => createDocument.mutate(..., { onError: rej, onSuccess: res }),
        // Rest omitted for brevity...
      ])
    },
  })
}
```

The internal mutate calls work fine but the `wrapperMutation.status` does not seem to be properly updated (stays stuck in `pending`) based on my limited testing. We have a couple of places where it is preferred to perform mutations in parallel so it'd be nice to enable that usage.

Based on some brief testing, using `mutateAsync` instead works as expected:

```tsx
function MutateAsyncExample() {
  const createDocument = useCreateDocument(...)

  const wrapperMutation = useMutation({
    mutationFn: async () => {
      // Some other work before this
      return Promise.all([
        createDocument.mutateAsync(...),
        createDocument.mutateAsync(...),
        // Rest omitted for brevity...
      ])
    },
  })
}
```

My guess is that how `mutate` is [implemented](https://github.com/TanStack/query/blob/96a8c1d3e791c72c0146c3acb1e2d6d31fb0ff6d/packages/react-query/src/useMutation.ts#L52) results in a subtle difference compared to `mutateAsync` in this scenario. I haven't explored very deeply but I wouldn't be surprised if wrapping `mutate` with a promise to emulate `mutateAsync` is generally not recommended by React Query, as opposed to using `mutateAsync` directly.