### PR TITLE
feat!: add initial invites-related read hooks

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -31,6 +31,7 @@
 - [useCreateDocument](#usecreatedocument)
 - [useUpdateDocument](#useupdatedocument)
 - [useDeleteDocument](#usedeletedocument)
+- [useInvitesListeners](#useinviteslisteners)
 - [useManyInvites](#usemanyinvites)
 - [useSingleInvite](#usesingleinvite)
 - [useAcceptInvite](#useacceptinvite)
@@ -88,7 +89,7 @@ Retrieve info about the current device.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useOwnDeviceInfo` | `() => { data: { deviceId: string; deviceType: "device_type_unspecified" or "mobile" or "tablet" or "desktop" or "selfHostedServer" or "UNRECOGNIZED"; } and Partial<DeviceInfoParam>; error: Error or null; isRefetching: boolean; }` |
+| `useOwnDeviceInfo` | `() => { data: { deviceId: string; deviceType: "UNRECOGNIZED" or "device_type_unspecified" or "mobile" or "tablet" or "desktop" or "selfHostedServer"; } and Partial<DeviceInfoParam>; error: Error or null; isRefetching: boolean; }` |
 
 Examples:
 
@@ -122,7 +123,7 @@ Update the device info for the current device.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useSetOwnDeviceInfo` | `() => { error: Error; mutate: UseMutateFunction<void, Error, { name: string; deviceType: "device_type_unspecified" or "mobile" or "tablet" or "desktop" or "selfHostedServer" or "UNRECOGNIZED"; }, unknown>; reset: () => void; status: "error"; } or { ...; }` |
+| `useSetOwnDeviceInfo` | `() => { error: Error; mutate: UseMutateFunction<void, Error, { name: string; deviceType: "UNRECOGNIZED" or "device_type_unspecified" or "mobile" or "tablet" or "desktop" or "selfHostedServer"; }, unknown>; reset: () => void; status: "error"; } or { ...; }` |
 
 ### useSetIsArchiveDevice
 
@@ -526,7 +527,7 @@ Triggers the closest error boundary if the document cannot be found
 
 | Function | Type |
 | ---------- | ---------- |
-| `useSingleDocByDocId` | `<D extends WriteableDocumentType>({ projectId, docType, docId, lang, }: { projectId: string; docType: D; docId: string; lang?: string or undefined; }) => ReadHookResult<Extract<{ schemaName: "deviceInfo"; name: string; deviceType: "device_type_unspecified" or ... 4 more ... or "UNRECOGNIZED"; ... 7 more ...; deleted: b...` |
+| `useSingleDocByDocId` | `<D extends WriteableDocumentType>({ projectId, docType, docId, lang, }: { projectId: string; docType: D; docId: string; lang?: string or undefined; }) => ReadHookResult<Extract<{ schemaName: "deviceInfo"; name: string; deviceType: "UNRECOGNIZED" or ... 4 more ... or "selfHostedServer"; ... 7 more ...; deleted: boolean;...` |
 
 Parameters:
 
@@ -559,7 +560,7 @@ Triggers the closest error boundary if the document cannot be found.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useSingleDocByVersionId` | `<D extends WriteableDocumentType>({ projectId, docType, versionId, lang, }: { projectId: string; docType: D; versionId: string; lang?: string or undefined; }) => ReadHookResult<Extract<{ schemaName: "deviceInfo"; name: string; deviceType: "device_type_unspecified" or ... 4 more ... or "UNRECOGNIZED"; ... 7 more ...; de...` |
+| `useSingleDocByVersionId` | `<D extends WriteableDocumentType>({ projectId, docType, versionId, lang, }: { projectId: string; docType: D; versionId: string; lang?: string or undefined; }) => ReadHookResult<Extract<{ schemaName: "deviceInfo"; name: string; deviceType: "UNRECOGNIZED" or ... 4 more ... or "selfHostedServer"; ... 7 more ...; deleted: ...` |
 
 Parameters:
 
@@ -592,7 +593,7 @@ Retrieve all documents of a specific `docType`.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useManyDocs` | `<D extends WriteableDocumentType>({ projectId, docType, includeDeleted, lang, }: { projectId: string; docType: D; includeDeleted?: boolean or undefined; lang?: string or undefined; }) => ReadHookResult<(Extract<{ schemaName: "deviceInfo"; name: string; deviceType: "device_type_unspecified" or ... 4 more ... or "UNRECOGN...` |
+| `useManyDocs` | `<D extends WriteableDocumentType>({ projectId, docType, includeDeleted, lang, }: { projectId: string; docType: D; includeDeleted?: boolean or undefined; lang?: string or undefined; }) => ReadHookResult<(Extract<{ schemaName: "deviceInfo"; name: string; deviceType: "UNRECOGNIZED" or ... 4 more ... or "selfHostedServer"; ...` |
 
 Parameters:
 
@@ -670,6 +671,28 @@ Parameters:
 
 * `opts.docType`: Document type to delete.
 * `opts.projectId`: Public ID of project document belongs to.
+
+
+### useInvitesListeners
+
+Set up listeners for received and updated invites.
+It is necessary to use this if you want the invites-related read hooks to update
+based on invites that are received or changed in the background.
+
+| Function | Type |
+| ---------- | ---------- |
+| `useInvitesListeners` | `() => void` |
+
+Examples:
+
+```tsx
+function App() {
+  // Use this somewhere near the root of the application
+  useInvitesListener()
+
+  return <RestOfApp />
+}
+```
 
 
 ### useManyInvites

--- a/docs/API.md
+++ b/docs/API.md
@@ -31,7 +31,7 @@
 - [useCreateDocument](#usecreatedocument)
 - [useUpdateDocument](#useupdatedocument)
 - [useDeleteDocument](#usedeletedocument)
-- [useInvitesListeners](#useinviteslisteners)
+- [useSetUpInvitesListeners](#usesetupinviteslisteners)
 - [useManyInvites](#usemanyinvites)
 - [useSingleInvite](#usesingleinvite)
 - [useAcceptInvite](#useacceptinvite)
@@ -673,7 +673,7 @@ Parameters:
 * `opts.projectId`: Public ID of project document belongs to.
 
 
-### useInvitesListeners
+### useSetUpInvitesListeners
 
 Set up listeners for received and updated invites.
 It is necessary to use this if you want the invites-related read hooks to update
@@ -681,14 +681,14 @@ based on invites that are received or changed in the background.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useInvitesListeners` | `() => void` |
+| `useSetUpInvitesListeners` | `() => void` |
 
 Examples:
 
 ```tsx
 function App() {
   // Use this somewhere near the root of the application
-  useInvitesListener()
+  useSetUpInvitesListeners()
 
   return <RestOfApp />
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -123,7 +123,7 @@ Update the device info for the current device.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useSetOwnDeviceInfo` | `() => { error: Error; mutate: UseMutateFunction<void, Error, { name: string; deviceType: "UNRECOGNIZED" or "device_type_unspecified" or "mobile" or "tablet" or "desktop" or "selfHostedServer"; }, unknown>; reset: () => void; status: "error"; } or { ...; }` |
+| `useSetOwnDeviceInfo` | `() => { error: Error; mutate: UseMutateFunction<void, Error, { name: string; deviceType: "UNRECOGNIZED" or "device_type_unspecified" or "mobile" or "tablet" or "desktop" or "selfHostedServer"; }, unknown>; mutateAsync: UseMutateAsyncFunction<...>; reset: () => void; status: "error"; } or { ...; }` |
 
 ### useSetIsArchiveDevice
 
@@ -131,7 +131,7 @@ Set or unset the current device as an archive device.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useSetIsArchiveDevice` | `() => { error: Error; mutate: UseMutateFunction<void, Error, { isArchiveDevice: boolean; }, unknown>; reset: () => void; status: "error"; } or { error: null; mutate: UseMutateFunction<...>; reset: () => void; status: "pending" or ... 1 more ... or "idle"; }` |
+| `useSetIsArchiveDevice` | `() => { error: Error; mutate: UseMutateFunction<void, Error, { isArchiveDevice: boolean; }, unknown>; mutateAsync: UseMutateAsyncFunction<void, Error, { isArchiveDevice: boolean; }, unknown>; reset: () => void; status: "error"; } or { ...; }` |
 
 ### useProjectSettings
 
@@ -410,7 +410,7 @@ function BasicExample() {
 
 | Function | Type |
 | ---------- | ---------- |
-| `useAddServerPeer` | `({ projectId }: { projectId: string; }) => { error: Error; mutate: UseMutateFunction<void, Error, { baseUrl: string; dangerouslyAllowInsecureConnections?: boolean or undefined; }, unknown>; reset: () => void; status: "error"; } or { ...; }` |
+| `useAddServerPeer` | `({ projectId }: { projectId: string; }) => { error: Error; mutate: UseMutateFunction<void, Error, { baseUrl: string; dangerouslyAllowInsecureConnections?: boolean or undefined; }, unknown>; mutateAsync: UseMutateAsyncFunction<...>; reset: () => void; status: "error"; } or { ...; }` |
 
 ### useCreateProject
 
@@ -418,7 +418,7 @@ Create a new project.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useCreateProject` | `() => { error: Error; mutate: UseMutateFunction<string, Error, { name?: string or undefined; configPath?: string or undefined; } or undefined, unknown>; reset: () => void; status: "error"; } or { ...; }` |
+| `useCreateProject` | `() => { error: Error; mutate: UseMutateFunction<string, Error, { name?: string or undefined; configPath?: string or undefined; } or undefined, unknown>; mutateAsync: UseMutateAsyncFunction<...>; reset: () => void; status: "error"; } or { ...; }` |
 
 ### useLeaveProject
 
@@ -426,7 +426,7 @@ Leave an existing project.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useLeaveProject` | `() => { error: Error; mutate: UseMutateFunction<void, Error, { projectId: string; }, unknown>; reset: () => void; status: "error"; } or { error: null; mutate: UseMutateFunction<void, Error, { ...; }, unknown>; reset: () => void; status: "pending" or ... 1 more ... or "idle"; }` |
+| `useLeaveProject` | `() => { error: Error; mutate: UseMutateFunction<void, Error, { projectId: string; }, unknown>; mutateAsync: UseMutateAsyncFunction<void, Error, { projectId: string; }, unknown>; reset: () => void; status: "error"; } or { ...; }` |
 
 ### useImportProjectConfig
 
@@ -434,7 +434,7 @@ Update the configuration of a project using an external file.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useImportProjectConfig` | `({ projectId }: { projectId: string; }) => { error: Error; mutate: UseMutateFunction<Error[], Error, { configPath: string; }, unknown>; reset: () => void; status: "error"; } or { ...; }` |
+| `useImportProjectConfig` | `({ projectId }: { projectId: string; }) => { error: Error; mutate: UseMutateFunction<Error[], Error, { configPath: string; }, unknown>; mutateAsync: UseMutateAsyncFunction<Error[], Error, { ...; }, unknown>; reset: () => void; status: "error"; } or { ...; }` |
 
 Parameters:
 
@@ -447,7 +447,7 @@ Update the settings of a project.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useUpdateProjectSettings` | `({ projectId }: { projectId: string; }) => { error: Error; mutate: UseMutateFunction<EditableProjectSettings, Error, { name?: string or undefined; configMetadata?: { ...; } or undefined; defaultPresets?: { ...; } or undefined; }, unknown>; reset: () => void; status: "error"; } or { ...; }` |
+| `useUpdateProjectSettings` | `({ projectId }: { projectId: string; }) => { error: Error; mutate: UseMutateFunction<EditableProjectSettings, Error, { name?: string or undefined; configMetadata?: { ...; } or undefined; defaultPresets?: { ...; } or undefined; }, unknown>; mutateAsync: UseMutateAsyncFunction<...>; reset: () => void; status: "error"; } ...` |
 
 Parameters:
 
@@ -460,7 +460,7 @@ Create a blob for a project.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useCreateBlob` | `({ projectId }: { projectId: string; }) => { error: Error; mutate: UseMutateFunction<{ driveId: string; name: string; type: "photo" or "audio" or "video"; hash: string; }, Error, { original: string; preview?: string or undefined; thumbnail?: string or undefined; metadata: Metadata; }, unknown>; reset: () => void; status...` |
+| `useCreateBlob` | `({ projectId }: { projectId: string; }) => { error: Error; mutate: UseMutateFunction<{ driveId: string; name: string; type: "photo" or "audio" or "video"; hash: string; }, Error, { original: string; preview?: string or undefined; thumbnail?: string or undefined; metadata: Metadata; }, unknown>; mutateAsync: UseMutateAsy...` |
 
 Parameters:
 
@@ -511,13 +511,13 @@ Provides the progress of data sync for sync-enabled connected peers
 
 | Function | Type |
 | ---------- | ---------- |
-| `useStartSync` | `({ projectId }: { projectId: string; }) => { error: Error; mutate: UseMutateFunction<void, Error, { autostopDataSyncAfter: number or null; } or undefined, unknown>; reset: () => void; status: "error"; } or { ...; }` |
+| `useStartSync` | `({ projectId }: { projectId: string; }) => { error: Error; mutate: UseMutateFunction<void, Error, { autostopDataSyncAfter: number or null; } or undefined, unknown>; mutateAsync: UseMutateAsyncFunction<...>; reset: () => void; status: "error"; } or { ...; }` |
 
 ### useStopSync
 
 | Function | Type |
 | ---------- | ---------- |
-| `useStopSync` | `({ projectId }: { projectId: string; }) => { error: Error; mutate: UseMutateFunction<void, Error, void, unknown>; reset: () => void; status: "error"; } or { error: null; mutate: UseMutateFunction<...>; reset: () => void; status: "pending" or ... 1 more ... or "idle"; }` |
+| `useStopSync` | `({ projectId }: { projectId: string; }) => { error: Error; mutate: UseMutateFunction<void, Error, void, unknown>; mutateAsync: UseMutateAsyncFunction<void, Error, void, unknown>; reset: () => void; status: "error"; } or { ...; }` |
 
 ### useSingleDocByDocId
 
@@ -637,7 +637,7 @@ Create a document for a project.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useCreateDocument` | `<D extends WriteableDocumentType>({ docType, projectId, }: { docType: D; projectId: string; }) => { error: Error; mutate: UseMutateFunction<WriteableDocument<D> and { forks: string[]; }, Error, { ...; }, unknown>; reset: () => void; status: "error"; } or { ...; }` |
+| `useCreateDocument` | `<D extends WriteableDocumentType>({ docType, projectId, }: { docType: D; projectId: string; }) => { error: Error; mutate: UseMutateFunction<WriteableDocument<D> and { forks: string[]; }, Error, { ...; }, unknown>; mutateAsync: UseMutateAsyncFunction<...>; reset: () => void; status: "error"; } or { ...; }` |
 
 Parameters:
 
@@ -651,7 +651,7 @@ Update a document within a project.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useUpdateDocument` | `<D extends WriteableDocumentType>({ docType, projectId, }: { docType: D; projectId: string; }) => { error: Error; mutate: UseMutateFunction<WriteableDocument<D> and { forks: string[]; }, Error, { ...; }, unknown>; reset: () => void; status: "error"; } or { ...; }` |
+| `useUpdateDocument` | `<D extends WriteableDocumentType>({ docType, projectId, }: { docType: D; projectId: string; }) => { error: Error; mutate: UseMutateFunction<WriteableDocument<D> and { forks: string[]; }, Error, { ...; }, unknown>; mutateAsync: UseMutateAsyncFunction<...>; reset: () => void; status: "error"; } or { ...; }` |
 
 Parameters:
 
@@ -665,7 +665,7 @@ Delete a document within a project.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useDeleteDocument` | `<D extends WriteableDocumentType>({ docType, projectId, }: { docType: D; projectId: string; }) => { error: Error; mutate: UseMutateFunction<WriteableDocument<D> and { forks: string[]; }, Error, { ...; }, unknown>; reset: () => void; status: "error"; } or { ...; }` |
+| `useDeleteDocument` | `<D extends WriteableDocumentType>({ docType, projectId, }: { docType: D; projectId: string; }) => { error: Error; mutate: UseMutateFunction<WriteableDocument<D> and { forks: string[]; }, Error, { ...; }, unknown>; mutateAsync: UseMutateAsyncFunction<...>; reset: () => void; status: "error"; } or { ...; }` |
 
 Parameters:
 
@@ -740,7 +740,7 @@ Accept an invite that has been received.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useAcceptInvite` | `() => { error: Error; mutate: UseMutateFunction<string, Error, { inviteId: string; }, unknown>; reset: () => void; status: "error"; } or { error: null; mutate: UseMutateFunction<string, Error, { ...; }, unknown>; reset: () => void; status: "pending" or ... 1 more ... or "idle"; }` |
+| `useAcceptInvite` | `() => { error: Error; mutate: UseMutateFunction<string, Error, { inviteId: string; }, unknown>; mutateAsync: UseMutateAsyncFunction<string, Error, { inviteId: string; }, unknown>; reset: () => void; status: "error"; } or { ...; }` |
 
 ### useRejectInvite
 
@@ -748,7 +748,7 @@ Reject an invite that has been received.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useRejectInvite` | `() => { error: Error; mutate: UseMutateFunction<void, Error, { inviteId: string; }, unknown>; reset: () => void; status: "error"; } or { error: null; mutate: UseMutateFunction<void, Error, { ...; }, unknown>; reset: () => void; status: "pending" or ... 1 more ... or "idle"; }` |
+| `useRejectInvite` | `() => { error: Error; mutate: UseMutateFunction<void, Error, { inviteId: string; }, unknown>; mutateAsync: UseMutateAsyncFunction<void, Error, { inviteId: string; }, unknown>; reset: () => void; status: "error"; } or { ...; }` |
 
 ### useSendInvite
 
@@ -756,7 +756,7 @@ Send an invite for a project.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useSendInvite` | `({ projectId }: { projectId: string; }) => { error: Error; mutate: UseMutateFunction<"ACCEPT" or "REJECT" or "ALREADY", Error, { deviceId: string; roleDescription?: string or undefined; roleId: "f7c150f5a3a9a855" or "012fd2d431c0bf60" or "9e6d29263cba36c9"; roleName?: string or undefined; }, unknown>; reset: () => void; s...` |
+| `useSendInvite` | `({ projectId }: { projectId: string; }) => { error: Error; mutate: UseMutateFunction<"ACCEPT" or "REJECT" or "ALREADY", Error, { deviceId: string; roleDescription?: string or undefined; roleId: "f7c150f5a3a9a855" or "012fd2d431c0bf60" or "9e6d29263cba36c9"; roleName?: string or undefined; }, unknown>; mutateAsync: UseMuta...` |
 
 Parameters:
 
@@ -769,7 +769,7 @@ Request a cancellation of an invite sent to another device.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useRequestCancelInvite` | `({ projectId }: { projectId: string; }) => { error: Error; mutate: UseMutateFunction<void, Error, { deviceId: string; }, unknown>; reset: () => void; status: "error"; } or { ...; }` |
+| `useRequestCancelInvite` | `({ projectId }: { projectId: string; }) => { error: Error; mutate: UseMutateFunction<void, Error, { deviceId: string; }, unknown>; mutateAsync: UseMutateAsyncFunction<void, Error, { ...; }, unknown>; reset: () => void; status: "error"; } or { ...; }` |
 
 Parameters:
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -31,6 +31,8 @@
 - [useCreateDocument](#usecreatedocument)
 - [useUpdateDocument](#useupdatedocument)
 - [useDeleteDocument](#usedeletedocument)
+- [useManyInvites](#usemanyinvites)
+- [useSingleInvite](#usesingleinvite)
 - [useAcceptInvite](#useacceptinvite)
 - [useRejectInvite](#userejectinvite)
 - [useSendInvite](#usesendinvite)
@@ -668,6 +670,45 @@ Parameters:
 
 * `opts.docType`: Document type to delete.
 * `opts.projectId`: Public ID of project document belongs to.
+
+
+### useManyInvites
+
+Get all invites that the device has received.
+
+| Function | Type |
+| ---------- | ---------- |
+| `useManyInvites` | `() => { data: Invite[]; error: Error or null; isRefetching: boolean; }` |
+
+Examples:
+
+```ts
+function Example() {
+  const { data } = useManyInvites()
+}
+```
+
+
+### useSingleInvite
+
+Get a single invite based on its ID.
+
+| Function | Type |
+| ---------- | ---------- |
+| `useSingleInvite` | `({ inviteId }: { inviteId: string; }) => { data: Invite; error: Error or null; isRefetching: boolean; }` |
+
+Parameters:
+
+* `opts.inviteId`: ID of invite
+
+
+Examples:
+
+```ts
+function Example() {
+  const { data } = useSingleInvite({ inviteId: '...' })
+}
+```
 
 
 ### useAcceptInvite

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@comapeo/core": "3.0.0-0",
-				"@comapeo/ipc": "2.1.0",
+				"@comapeo/ipc": "file:comapeo-ipc-2.1.0.tgz",
 				"@comapeo/schema": "1.4.1",
 				"@eslint/compat": "1.2.7",
 				"@eslint/js": "9.23.0",
@@ -296,8 +296,8 @@
 		},
 		"node_modules/@comapeo/ipc": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@comapeo/ipc/-/ipc-2.1.0.tgz",
-			"integrity": "sha512-awrVjwI25wJVX1OoE4yBBdWP7rLO/lHeYfjne2wk7ecuuO5abekKUQ0QFoKLpvo94LNnK+K61jRrEN5A4FY9lw==",
+			"resolved": "file:comapeo-ipc-2.1.0.tgz",
+			"integrity": "sha512-ujDX9YJCy8OJZIYqsnJwGuhkWA/l9YkvBpVri0glnLY11ZclxqvydHLrkCdvVf+m0BpcuzE1eq8Ej8DgFQeGUg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -309,7 +309,7 @@
 				"node": ">=18.17.1"
 			},
 			"peerDependencies": {
-				"@comapeo/core": "^2.2.0"
+				"@comapeo/core": "3.0.0-0"
 			}
 		},
 		"node_modules/@comapeo/schema": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "3.3.0",
 			"license": "MIT",
 			"devDependencies": {
-				"@comapeo/core": "3.0.0-0",
-				"@comapeo/ipc": "file:comapeo-ipc-2.1.0.tgz",
+				"@comapeo/core": "3.0.0",
+				"@comapeo/ipc": "3.0.0",
 				"@comapeo/schema": "1.4.1",
 				"@eslint/compat": "1.2.7",
 				"@eslint/js": "9.23.0",
@@ -40,8 +40,8 @@
 				"vitest": "3.0.9"
 			},
 			"peerDependencies": {
-				"@comapeo/core": "*",
-				"@comapeo/ipc": "*",
+				"@comapeo/core": "^3.0.0",
+				"@comapeo/ipc": "^3.0.0",
 				"@comapeo/schema": "*",
 				"@tanstack/react-query": "^5",
 				"react": "^18 || ^19"
@@ -187,9 +187,9 @@
 			}
 		},
 		"node_modules/@comapeo/core": {
-			"version": "3.0.0-0",
-			"resolved": "https://registry.npmjs.org/@comapeo/core/-/core-3.0.0-0.tgz",
-			"integrity": "sha512-80G3UWCmxKrewVGdXdObPWHxBQr262nI/xU1NCMYyTqN7d2CouslR90HKcKJOrKXoPPLREcyYMytC8hulkrqVg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@comapeo/core/-/core-3.0.0.tgz",
+			"integrity": "sha512-0+wRo035A6nDbsSwbyLKHZ2XiEeG88781xuwKWTTotY6tqmI1FQQMkL/Ncf1xqlY2E5h/go+Wu9Svzu7G+8Ubw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -295,9 +295,9 @@
 			}
 		},
 		"node_modules/@comapeo/ipc": {
-			"version": "2.1.0",
-			"resolved": "file:comapeo-ipc-2.1.0.tgz",
-			"integrity": "sha512-ujDX9YJCy8OJZIYqsnJwGuhkWA/l9YkvBpVri0glnLY11ZclxqvydHLrkCdvVf+m0BpcuzE1eq8Ej8DgFQeGUg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@comapeo/ipc/-/ipc-3.0.0.tgz",
+			"integrity": "sha512-t6Y136RAAfMeaDznZmL9PJoqWmds36mUNvLWvnrMwOqdlcbHBYVXZ4mpYqVpZ70azCTYegA99Phu2gm4WIh9QA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -309,7 +309,7 @@
 				"node": ">=18.17.1"
 			},
 			"peerDependencies": {
-				"@comapeo/core": "3.0.0-0"
+				"@comapeo/core": "^3.0.0"
 			}
 		},
 		"node_modules/@comapeo/schema": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "3.3.0",
 			"license": "MIT",
 			"devDependencies": {
-				"@comapeo/core": "2.3.1",
+				"@comapeo/core": "3.0.0-0",
 				"@comapeo/ipc": "2.1.0",
 				"@comapeo/schema": "1.4.1",
 				"@eslint/compat": "1.2.7",
@@ -187,9 +187,9 @@
 			}
 		},
 		"node_modules/@comapeo/core": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/@comapeo/core/-/core-2.3.1.tgz",
-			"integrity": "sha512-7nLnCqaOU0EYj2i0FirGlk+M3TKIHSi7WDu9HYiTE3EpQpElHlci7iv70Ic8uQg2Hkk/wnmKXJq7+RJ1yutsVw==",
+			"version": "3.0.0-0",
+			"resolved": "https://registry.npmjs.org/@comapeo/core/-/core-3.0.0-0.tgz",
+			"integrity": "sha512-80G3UWCmxKrewVGdXdObPWHxBQr262nI/xU1NCMYyTqN7d2CouslR90HKcKJOrKXoPPLREcyYMytC8hulkrqVg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -213,10 +213,11 @@
 				"debug": "^4.3.4",
 				"dot-prop": "^9.0.0",
 				"drizzle-orm": "^0.30.8",
+				"ensure-error": "^4.0.0",
 				"fastify": "^4.0.0",
 				"fastify-plugin": "^4.5.1",
 				"hyperblobs": "2.3.0",
-				"hypercore": "10.17.0",
+				"hypercore": "10.19.0",
 				"hypercore-crypto": "3.4.2",
 				"hyperdrive": "11.5.3",
 				"json-stable-stringify": "^1.1.1",
@@ -243,6 +244,7 @@
 				"unix-path-resolve": "^1.0.2",
 				"varint": "^6.0.0",
 				"ws": "^8.18.0",
+				"xstate": "^5.19.2",
 				"yauzl-promise": "^4.0.0"
 			}
 		},
@@ -4310,6 +4312,19 @@
 				"once": "^1.4.0"
 			}
 		},
+		"node_modules/ensure-error": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/ensure-error/-/ensure-error-4.0.0.tgz",
+			"integrity": "sha512-7Xenn3+R6tp2UqAbH9Jqs6QCSABQok+1VAhaPaF0jjm3iuhVHCblfBh18nYtpm3K9/V4Jpxz1JIqFZyrjstBtw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/entities": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -5545,9 +5560,9 @@
 			}
 		},
 		"node_modules/hypercore": {
-			"version": "10.17.0",
-			"resolved": "https://registry.npmjs.org/hypercore/-/hypercore-10.17.0.tgz",
-			"integrity": "sha512-Yp9lyfUjp81Gy1nPHemNFtYQtngliCGZ6prH+qxvjr2FPVG1QFtNqtOh+ZxFu4hXZ1dAOLYkQOA7Qq2vjFe64A==",
+			"version": "10.19.0",
+			"resolved": "https://registry.npmjs.org/hypercore/-/hypercore-10.19.0.tgz",
+			"integrity": "sha512-vdK9QC2BmylhL1gqUYBICgRLHYhPqX6f4iOYfQKqcV+xOkiLIJglBNLHIUVYHqGw5W0YunhRzbpA/9IhPtrJOw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5557,10 +5572,12 @@
 				"compact-encoding": "^2.11.0",
 				"crc-universal": "^1.0.2",
 				"events": "^3.3.0",
+				"fast-fifo": "^1.3.0",
 				"flat-tree": "^1.9.0",
 				"hypercore-crypto": "^3.2.1",
+				"hypercore-errors": "^1.0.0",
 				"is-options": "^1.0.1",
-				"protomux": "^3.4.0",
+				"protomux": "^3.5.0",
 				"quickbit-universal": "^2.1.1",
 				"random-access-file": "^4.0.0",
 				"random-array-iterator": "^1.0.0",
@@ -10145,6 +10162,17 @@
 			"license": "MIT",
 			"optional": true,
 			"peer": true
+		},
+		"node_modules/xstate": {
+			"version": "5.19.2",
+			"resolved": "https://registry.npmjs.org/xstate/-/xstate-5.19.2.tgz",
+			"integrity": "sha512-B8fL2aP0ogn5aviAXFzI5oZseAMqN00fg/TeDa3ZtatyDcViYLIfuQl4y8qmHCiKZgGEzmnTyNtNQL9oeJE2gw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/xstate"
+			}
 		},
 		"node_modules/yaml": {
 			"version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -57,15 +57,15 @@
 		"types": "tsc"
 	},
 	"peerDependencies": {
-		"@comapeo/core": "*",
-		"@comapeo/ipc": "*",
+		"@comapeo/core": "^3.0.0",
+		"@comapeo/ipc": "^3.0.0",
 		"@comapeo/schema": "*",
 		"@tanstack/react-query": "^5",
 		"react": "^18 || ^19"
 	},
 	"devDependencies": {
-		"@comapeo/core": "3.0.0-0",
-		"@comapeo/ipc": "file:comapeo-ipc-2.1.0.tgz",
+		"@comapeo/core": "3.0.0",
+		"@comapeo/ipc": "3.0.0",
 		"@comapeo/schema": "1.4.1",
 		"@eslint/compat": "1.2.7",
 		"@eslint/js": "9.23.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 	},
 	"devDependencies": {
 		"@comapeo/core": "3.0.0-0",
-		"@comapeo/ipc": "2.1.0",
+		"@comapeo/ipc": "file:comapeo-ipc-2.1.0.tgz",
 		"@comapeo/schema": "1.4.1",
 		"@eslint/compat": "1.2.7",
 		"@eslint/js": "9.23.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"react": "^18 || ^19"
 	},
 	"devDependencies": {
-		"@comapeo/core": "2.3.1",
+		"@comapeo/core": "3.0.0-0",
 		"@comapeo/ipc": "2.1.0",
 		"@comapeo/schema": "1.4.1",
 		"@eslint/compat": "1.2.7",

--- a/src/hooks/invites.ts
+++ b/src/hooks/invites.ts
@@ -26,13 +26,13 @@ import { useSingleProject } from './projects.js'
  * ```tsx
  * function App() {
  *   // Use this somewhere near the root of the application
- *   useInvitesListener()
+ *   useSetUpInvitesListeners()
  *
  *   return <RestOfApp />
  * }
  * ```
  */
-export function useInvitesListeners() {
+export function useSetUpInvitesListeners() {
 	const queryClient = useQueryClient()
 	const clientApi = useClientApi()
 

--- a/src/hooks/invites.ts
+++ b/src/hooks/invites.ts
@@ -3,10 +3,12 @@ import {
 	useQueryClient,
 	useSuspenseQuery,
 } from '@tanstack/react-query'
+import { useEffect } from 'react'
 
 import {
 	acceptInviteMutationOptions,
 	getInviteByIdQueryOptions,
+	getInvitesQueryKey,
 	getInvitesQueryOptions,
 	rejectInviteMutationOptions,
 	requestCancelInviteMutationOptions,
@@ -14,6 +16,40 @@ import {
 } from '../lib/react-query/invites.js'
 import { useClientApi } from './client.js'
 import { useSingleProject } from './projects.js'
+
+/**
+ * Set up listeners for received and updated invites.
+ * It is necessary to use this if you want the invites-related read hooks to update
+ * based on invites that are received or changed in the background.
+ *
+ * @example
+ * ```tsx
+ * function App() {
+ *   // Use this somewhere near the root of the application
+ *   useInvitesListener()
+ *
+ *   return <RestOfApp />
+ * }
+ * ```
+ */
+export function useInvitesListeners() {
+	const queryClient = useQueryClient()
+	const clientApi = useClientApi()
+
+	useEffect(() => {
+		function invalidateCache() {
+			queryClient.invalidateQueries({ queryKey: getInvitesQueryKey() })
+		}
+
+		clientApi.invite.addListener('invite-received', invalidateCache)
+		clientApi.invite.addListener('invite-updated', invalidateCache)
+
+		return () => {
+			clientApi.invite.removeListener('invite-received', invalidateCache)
+			clientApi.invite.removeListener('invite-updated', invalidateCache)
+		}
+	}, [clientApi, queryClient])
+}
 
 /**
  * Get all invites that the device has received.

--- a/src/hooks/invites.ts
+++ b/src/hooks/invites.ts
@@ -1,13 +1,60 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+	useMutation,
+	useQueryClient,
+	useSuspenseQuery,
+} from '@tanstack/react-query'
 
 import {
 	acceptInviteMutationOptions,
+	getInviteByIdQueryOptions,
+	getInvitesQueryOptions,
 	rejectInviteMutationOptions,
 	requestCancelInviteMutationOptions,
 	sendInviteMutationOptions,
 } from '../lib/react-query/invites.js'
 import { useClientApi } from './client.js'
 import { useSingleProject } from './projects.js'
+
+/**
+ * Get all invites that the device has received.
+ *
+ * @example
+ * ```ts
+ * function Example() {
+ *   const { data } = useManyInvites()
+ * }
+ * ```
+ */
+export function useManyInvites() {
+	const clientApi = useClientApi()
+	const { data, error, isRefetching } = useSuspenseQuery(
+		getInvitesQueryOptions({ clientApi }),
+	)
+
+	return { data, error, isRefetching }
+}
+
+/**
+ * Get a single invite based on its ID.
+ *
+ * @param opts.inviteId ID of invite
+ *
+ * @example
+ * ```ts
+ * function Example() {
+ *   const { data } = useSingleInvite({ inviteId: '...' })
+ * }
+ * ```
+ */
+export function useSingleInvite({ inviteId }: { inviteId: string }) {
+	const clientApi = useClientApi()
+
+	const { data, error, isRefetching } = useSuspenseQuery(
+		getInviteByIdQueryOptions({ clientApi, inviteId }),
+	)
+
+	return { data, error, isRefetching }
+}
 
 /**
  * Accept an invite that has been received.

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export {
 } from './hooks/documents.js'
 export {
 	useAcceptInvite,
-	useInvitesListeners,
+	useSetUpInvitesListeners,
 	useManyInvites,
 	useRejectInvite,
 	useRequestCancelInvite,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,9 +16,11 @@ export {
 } from './hooks/documents.js'
 export {
 	useAcceptInvite,
+	useManyInvites,
 	useRejectInvite,
 	useRequestCancelInvite,
 	useSendInvite,
+	useSingleInvite,
 } from './hooks/invites.js'
 export { useMapStyleUrl } from './hooks/maps.js'
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export {
 } from './hooks/documents.js'
 export {
 	useAcceptInvite,
+	useInvitesListeners,
 	useManyInvites,
 	useRejectInvite,
 	useRequestCancelInvite,

--- a/src/lib/react-query/invites.ts
+++ b/src/lib/react-query/invites.ts
@@ -20,20 +20,36 @@ export function getInvitesQueryKey() {
 	return [ROOT_QUERY_KEY, 'invites'] as const
 }
 
-export function getPendingInvitesQueryKey() {
-	return [ROOT_QUERY_KEY, 'invites', { status: 'pending' }] as const
+export function getInvitesByIdQueryKey({ inviteId }: { inviteId: string }) {
+	return [ROOT_QUERY_KEY, 'invites', { inviteId }] as const
 }
 
-export function pendingInvitesQueryOptions({
+export function getInvitesQueryOptions({
 	clientApi,
 }: {
 	clientApi: MapeoClientApi
 }) {
 	return queryOptions({
 		...baseQueryOptions(),
-		queryKey: getPendingInvitesQueryKey(),
+		queryKey: getInvitesQueryKey(),
 		queryFn: async () => {
-			return clientApi.invite.getPending()
+			return clientApi.invite.getMany()
+		},
+	})
+}
+
+export function getInviteByIdQueryOptions({
+	clientApi,
+	inviteId,
+}: {
+	clientApi: MapeoClientApi
+	inviteId: string
+}) {
+	return queryOptions({
+		...baseQueryOptions(),
+		queryKey: getInvitesByIdQueryKey({ inviteId }),
+		queryFn: async () => {
+			return clientApi.invite.getById(inviteId)
 		},
 	})
 }


### PR DESCRIPTION
Closes #8 

Adds the following hooks:

- `useSetUpInvitesListeners`
- `useSingleInvite`
- `useManyInvites`

Tests have not been implemented yet unfortunately, since it's non-trivial to set up. Will create a new issue to track that work.

This is a breaking change as the hooks are dependent on the updated invites API in core, meaning that `@comapeo/core@3.0.0` (or later) must be used.