### PR TITLE
feat: introduce useRemoveServerPeer hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
 				"vitest": "3.1.3"
 			},
 			"peerDependencies": {
-				"@comapeo/core": "^3.0.0",
+				"@comapeo/core": "^3.1.0",
 				"@comapeo/ipc": "^3.0.0",
 				"@comapeo/schema": "*",
 				"@tanstack/react-query": "^5",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"types": "tsc"
 	},
 	"peerDependencies": {
-		"@comapeo/core": "^3.0.0",
+		"@comapeo/core": "^3.1.0",
 		"@comapeo/ipc": "^3.0.0",
 		"@comapeo/schema": "*",
 		"@tanstack/react-query": "^5",

--- a/src/hooks/projects.ts
+++ b/src/hooks/projects.ts
@@ -26,6 +26,7 @@ import {
 	projectOwnRoleQueryOptions,
 	projectSettingsQueryOptions,
 	projectsQueryOptions,
+	removeServerPeerMutationOptions,
 	startSyncMutationOptions,
 	stopSyncMutationOptions,
 	updateProjectSettingsMutationOptions,
@@ -375,6 +376,19 @@ export function useAddServerPeer({ projectId }: { projectId: string }) {
 
 	const { error, mutate, mutateAsync, reset, status } = useMutation(
 		addServerPeerMutationOptions({ projectApi, projectId, queryClient }),
+	)
+
+	return status === 'error'
+		? { error, mutate, mutateAsync, reset, status }
+		: { error: null, mutate, mutateAsync, reset, status }
+}
+
+export function useRemoveServerPeer({ projectId }: { projectId: string }) {
+	const queryClient = useQueryClient()
+	const { data: projectApi } = useSingleProject({ projectId })
+
+	const { error, mutate, mutateAsync, reset, status } = useMutation(
+		removeServerPeerMutationOptions({ projectApi, projectId, queryClient }),
 	)
 
 	return status === 'error'

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export {
 	useManyProjects,
 	useOwnRoleInProject,
 	useProjectSettings,
+	useRemoveServerPeer,
 	useSingleMember,
 	useSingleProject,
 	useStartSync,

--- a/src/lib/react-query/projects.ts
+++ b/src/lib/react-query/projects.ts
@@ -283,6 +283,37 @@ export function addServerPeerMutationOptions({
 	>
 }
 
+export function removeServerPeerMutationOptions({
+	projectApi,
+	projectId,
+	queryClient,
+}: {
+	projectApi: MapeoProjectApi
+	projectId: string
+	queryClient: QueryClient
+}) {
+	return {
+		...baseMutationOptions(),
+		mutationFn: async ({
+			serverDeviceId,
+			dangerouslyAllowInsecureConnections,
+		}) => {
+			return projectApi.$member.removeServerPeer(serverDeviceId, {
+				dangerouslyAllowInsecureConnections,
+			})
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: getMembersQueryKey({ projectId }),
+			})
+		},
+	} satisfies UseMutationOptions<
+		void,
+		Error,
+		{ serverDeviceId: string; dangerouslyAllowInsecureConnections?: boolean }
+	>
+}
+
 export function createProjectMutationOptions({
 	clientApi,
 	queryClient,


### PR DESCRIPTION
Introduces a write hook for removing a server peer from a project. This requires `@comapeo/core@3.1.0`, which is technically a breaking change but I think it's okay to treat it as normal feature add.