### PR TITLE
chore: use correct version of @comapeo/schema in dev deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"devDependencies": {
 				"@comapeo/core": "3.1.1",
 				"@comapeo/ipc": "3.0.0",
-				"@comapeo/schema": "1.6.0",
+				"@comapeo/schema": "1.5.0",
 				"@eslint/compat": "1.2.9",
 				"@eslint/js": "9.26.0",
 				"@ianvs/prettier-plugin-sort-imports": "4.4.1",
@@ -251,19 +251,6 @@
 				"yauzl-promise": "^4.0.0"
 			}
 		},
-		"node_modules/@comapeo/core/node_modules/@comapeo/schema": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.5.0.tgz",
-			"integrity": "sha512-MIT9BSo34ffUKn6kZuBf10Xs3/7FZ2tVwXLi+Oi5DiOuTEI1r03DAI9XzGTqU2FsnPkza+dc5h6aaBB/ZuOsrA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@comapeo/geometry": "^1.1.1",
-				"compact-encoding": "^2.12.0",
-				"protobufjs": "^7.2.5",
-				"type-fest": "^4.26.0"
-			}
-		},
 		"node_modules/@comapeo/core/node_modules/corestore": {
 			"version": "6.8.4",
 			"resolved": "https://registry.npmjs.org/corestore/-/corestore-6.8.4.tgz",
@@ -329,9 +316,9 @@
 			}
 		},
 		"node_modules/@comapeo/schema": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.6.0.tgz",
-			"integrity": "sha512-Lk36pwUkGt/mEsOSEGWKSjUC+FWSu+qFJ4Cv0NpKRHF8+bORGBuVOsbmvnEiiZu0tTWncInBSBO0LoSEdseG8g==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.5.0.tgz",
+			"integrity": "sha512-MIT9BSo34ffUKn6kZuBf10Xs3/7FZ2tVwXLi+Oi5DiOuTEI1r03DAI9XzGTqU2FsnPkza+dc5h6aaBB/ZuOsrA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 	"devDependencies": {
 		"@comapeo/core": "3.1.1",
 		"@comapeo/ipc": "3.0.0",
-		"@comapeo/schema": "1.6.0",
+		"@comapeo/schema": "1.5.0",
 		"@eslint/compat": "1.2.9",
 		"@eslint/js": "9.26.0",
 		"@ianvs/prettier-plugin-sort-imports": "4.4.1",


### PR DESCRIPTION
I erroneously bumped this in #75 despite core still being tied to 1.5.0, causing two installations of it.