### PR TITLE
fix: update types for useUpdateProjectSettings to account for project color and description

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -457,7 +457,7 @@ Update the settings of a project.
 
 | Function | Type |
 | ---------- | ---------- |
-| `useUpdateProjectSettings` | `({ projectId }: { projectId: string; }) => { error: Error; mutate: UseMutateFunction<EditableProjectSettings, Error, { name?: string or undefined; configMetadata?: { ...; } or undefined; defaultPresets?: { ...; } or undefined; }, unknown>; mutateAsync: UseMutateAsyncFunction<...>; reset: () => void; status: "error"; } ...` |
+| `useUpdateProjectSettings` | `({ projectId }: { projectId: string; }) => { error: Error; mutate: UseMutateFunction<EditableProjectSettings, Error, { name?: string or undefined; configMetadata?: { ...; } or undefined; defaultPresets?: { ...; } or undefined; projectColor?: string or undefined; projectDescription?: string or undefined; }, unknown>; muta...` |
 
 Parameters:
 

--- a/src/lib/react-query/projects.ts
+++ b/src/lib/react-query/projects.ts
@@ -411,6 +411,8 @@ export function updateProjectSettingsMutationOptions({
 			name?: ProjectSettings['name']
 			configMetadata?: ProjectSettings['configMetadata']
 			defaultPresets?: ProjectSettings['defaultPresets']
+			projectColor?: ProjectSettings['projectColor']
+			projectDescription?: ProjectSettings['projectDescription']
 		}
 	>
 }


### PR DESCRIPTION
These fields were introduced in `@comapeo/core@3.1.0` (via `@comapeo/schema@1.5.0`)