### PR TITLE
feat: never refetch with `useDocumentCreatedBy()`

### DIFF
--- a/src/lib/react-query/projects.ts
+++ b/src/lib/react-query/projects.ts
@@ -237,6 +237,8 @@ export function documentCreatedByQueryOptions({
 		queryFn: async () => {
 			return projectApi.$originalVersionIdToDeviceId(originalVersionId)
 		},
+		staleTime: 'static',
+		gcTime: Infinity,
 	})
 }
 


### PR DESCRIPTION
`$originalVersionIdToDeviceId()` maps a versionId to a deviceId. It was a temporary workaround for this information not being included in the docs returned from the server, but it adds RPC round-trip overhead. The result of this query never changes for a given versionId, so it does not need to be refetched and can be cached for ever. Because there are never going to be more than a few hundred deviceIds in a project, I think it's ok to never garbage collect this data, and just keep them cached for ever.

This small change should reduce the number of RPC requests when re-visiting the observation list page.

This is a short-term fix — the longer-term fix is to return a `createdBy` field on docs returned from core, removing the need for the `useDocumentCreatedBy()` hook: https://github.com/digidem/comapeo-core/issues/136