### PR TITLE
feat: get attachment and icon URLs without async requests

### DIFF
--- a/src/lib/react-query/projects.ts
+++ b/src/lib/react-query/projects.ts
@@ -201,27 +201,28 @@ export function documentCreatedByQueryOptions({
 	})
 }
 
+// Used as a placeholder so that we can read the server port from the $blobs.getUrl() method
+const FAKE_BLOB_ID: BlobApi.BlobId = {
+	type: 'photo',
+	variant: 'original',
+	name: 'name',
+	driveId: 'drive-id',
+}
+
 export function mediaServerPortQueryOptions({
 	projectApi,
 }: {
 	projectApi: MapeoProjectApi
 }) {
-	const fakeBlobId: BlobApi.BlobId = {
-		type: 'photo',
-		variant: 'original',
-		name: 'name',
-		driveId: 'drive-id',
-	}
 	return queryOptions({
 		...baseQueryOptions(),
 		// HACK: The server doesn't yet expose a method to get its port, so we use
 		// the existing $blobs.getUrl() to get the port with a fake BlobId. The port
 		// is the same regardless of the blobId, so it's not necessary to include it
 		// as a dep for the query key.
-		// eslint-disable-next-line @tanstack/query/exhaustive-deps
 		queryKey: getMediaServerPortQueryKey(),
 		queryFn: async () => {
-			const url = await projectApi.$blobs.getUrl(fakeBlobId)
+			const url = await projectApi.$blobs.getUrl(FAKE_BLOB_ID)
 			return new URL(url).port
 		},
 		staleTime: 'static',

--- a/src/lib/react-query/projects.ts
+++ b/src/lib/react-query/projects.ts
@@ -1,7 +1,6 @@
 import type {
 	BlobApi,
 	EditableProjectSettings,
-	IconApi,
 } from '@comapeo/core' with { 'resolution-mode': 'import' }
 import type {
 	MapeoClientApi,
@@ -55,24 +54,6 @@ export function getMemberByIdQueryKey({
 	return [ROOT_QUERY_KEY, 'projects', projectId, 'members', deviceId] as const
 }
 
-export function getIconUrlQueryKey({
-	projectId,
-	iconId,
-	...mimeBasedOpts
-}: {
-	projectId: string
-	iconId: string
-} & (IconApi.BitmapOpts | IconApi.SvgOpts)) {
-	return [
-		ROOT_QUERY_KEY,
-		'projects',
-		projectId,
-		'icons',
-		iconId,
-		mimeBasedOpts,
-	] as const
-}
-
 export function getDocumentCreatedByQueryKey({
 	projectId,
 	originalVersionId,
@@ -89,14 +70,13 @@ export function getDocumentCreatedByQueryKey({
 	] as const
 }
 
-export function getAttachmentUrlQueryKey({
-	projectId,
-	blobId,
-}: {
-	projectId: string
-	blobId: BlobApi.BlobId
-}) {
-	return [ROOT_QUERY_KEY, 'projects', projectId, 'attachments', blobId] as const
+/**
+ * We call this within a project hook, because that's the only place the API is
+ * exposed right now, but it is the same for all projects, so no need for
+ * scoping the query key to the project
+ */
+export function getMediaServerPortQueryKey() {
+	return [ROOT_QUERY_KEY, 'media_server_port'] as const
 }
 
 export function projectsQueryOptions({
@@ -200,25 +180,6 @@ export function projectOwnRoleQueryOptions({
 	})
 }
 
-export function iconUrlQueryOptions({
-	projectApi,
-	projectId,
-	iconId,
-	...mimeBasedOpts
-}: {
-	projectApi: MapeoProjectApi
-	projectId: string
-	iconId: Parameters<MapeoProjectApi['$icons']['getIconUrl']>[0]
-} & (IconApi.BitmapOpts | IconApi.SvgOpts)) {
-	return queryOptions({
-		...baseQueryOptions(),
-		queryKey: getIconUrlQueryKey({ ...mimeBasedOpts, projectId, iconId }),
-		queryFn: async () => {
-			return projectApi.$icons.getIconUrl(iconId, mimeBasedOpts)
-		},
-	})
-}
-
 export function documentCreatedByQueryOptions({
 	projectApi,
 	projectId,
@@ -240,22 +201,31 @@ export function documentCreatedByQueryOptions({
 	})
 }
 
-export function attachmentUrlQueryOptions({
+export function mediaServerPortQueryOptions({
 	projectApi,
-	projectId,
-	blobId,
 }: {
 	projectApi: MapeoProjectApi
-	projectId: string
-	blobId: BlobApi.BlobId
 }) {
+	const fakeBlobId: BlobApi.BlobId = {
+		type: 'photo',
+		variant: 'original',
+		name: 'name',
+		driveId: 'drive-id',
+	}
 	return queryOptions({
 		...baseQueryOptions(),
-		queryKey: getAttachmentUrlQueryKey({ projectId, blobId }),
+		// HACK: The server doesn't yet expose a method to get its port, so we use
+		// the existing $blobs.getUrl() to get the port with a fake BlobId. The port
+		// is the same regardless of the blobId, so it's not necessary to include it
+		// as a dep for the query key.
+		// eslint-disable-next-line @tanstack/query/exhaustive-deps
+		queryKey: getMediaServerPortQueryKey(),
 		queryFn: async () => {
-			// TODO: Might need a refresh token? (similar to map style url)
-			return projectApi.$blobs.getUrl(blobId)
+			const url = await projectApi.$blobs.getUrl(fakeBlobId)
+			return new URL(url).port
 		},
+		staleTime: 'static',
+		gcTime: Infinity,
 	})
 }
 

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -1,0 +1,92 @@
+// TODO: Move these into a separate "@comapeo/asset-server" module which can
+// export them to be imported directly in a client.
+
+import type { BlobApi, IconApi } from '@comapeo/core'
+
+const MIME_TO_EXTENSION = {
+	'image/png': '.png',
+	'image/svg+xml': '.svg',
+}
+
+/**
+ * Get a url for a blob based on its BlobId
+ */
+export function getBlobUrl(baseUrl: string, blobId: BlobApi.BlobId) {
+	const { driveId, type, variant, name } = blobId
+
+	if (!baseUrl.endsWith('/')) {
+		baseUrl += '/'
+	}
+
+	return baseUrl + `${driveId}/${type}/${variant}/${name}`
+}
+
+/**
+ * @param {string} iconId
+ * @param {BitmapOpts | SvgOpts} opts
+ *
+ * @returns {Promise<string>}
+ */
+export function getIconUrl(
+	baseUrl: string,
+	iconId: string,
+	opts: IconApi.BitmapOpts | IconApi.SvgOpts,
+) {
+	if (!baseUrl.endsWith('/')) {
+		baseUrl += '/'
+	}
+
+	const mimeExtension = MIME_TO_EXTENSION[opts.mimeType]
+
+	const pixelDensity =
+		opts.mimeType === 'image/svg+xml' ||
+		// if the pixel density is 1, we can omit the density suffix in the resulting url
+		// and assume the pixel density is 1 for applicable mime types when using the url
+		opts.pixelDensity === 1
+			? undefined
+			: opts.pixelDensity
+
+	return (
+		baseUrl +
+		constructIconPath({
+			pixelDensity,
+			size: opts.size,
+			extension: mimeExtension,
+			iconId,
+		})
+	)
+}
+
+type IconPathOptions = {
+	iconId: string
+	size: string
+	pixelDensity?: number
+	extension: string
+}
+
+/**
+ * General purpose path builder for an icon
+ */
+function constructIconPath({
+	size,
+	pixelDensity,
+	iconId,
+	extension,
+}: IconPathOptions): string {
+	if (iconId.length === 0 || size.length === 0 || extension.length === 0) {
+		throw new Error('iconId, size, and extension cannot be empty strings')
+	}
+
+	let result = `${iconId}/${size}`
+
+	if (typeof pixelDensity === 'number') {
+		if (pixelDensity < 1) {
+			throw new Error('pixelDensity must be a positive number')
+		}
+		result += `@${pixelDensity}x`
+	}
+
+	result += extension.startsWith('.') ? extension : '.' + extension
+
+	return result
+}


### PR DESCRIPTION
This is an initial fix for #96. This almost entirely removes RPC requests for icon and attachment URLs, by making a single request for the server port, and then returning all other URLs synchronously.

This includes a "hack" because we do not expose a method for getting the server port, and instead we use the existing `getBlobUrl` method with fake data to parse the port. Because the server lifecycle is maintained by application code, not comapeo-core, it probably doesn't make sense for core to implement an API for the server port, but instead create an API in application code and pass a getPort function to core-react, however that can be a follow-up that requires deeper changes.

This moves logic for URL structure into this library, temporarily, which needs to be kept in sync with the URL structure defined in the fastify plugins in Core. In a follow-up we can export functions from Core, or an extracted "core blob server", which will move the URL structure logic into one place, but this temporary fix is the quickest for now that minimizes changes to different modules.

This is slightly "hacky" under the surface, but the advantage is that there are zero API changes, and no changes needed to Core or application code, and it should _just work_ with a significant reduction in requests for URLs.

Follow-up work can clean this up, see #96.