### PR TITLE
fix: fix release workflow error from node 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,4 +45,4 @@ jobs:
           notify-linked-issues: false
           npm-token: ${{ secrets.NPM_TOKEN }}
           build-command: |
-            npm ci
+            npm ci --ignore-scripts


### PR DESCRIPTION
Node LTS has changed to v22, and the optic-release workflow runs in the context of node LTS, not the node version we setup in the previous step.

We are using an older version of better-sqlite3 at the moment, which does not include prebuilds for node v22. It's a dependency of @comapeo/core, which is a dev dep here for tests. better-sqlite3 has a postinstall script that tries to download prebuilds, which is failing on the optic release build command `npm ci`.

This PR adds `--ignore-scripts` to the optic release build command. This would have an impact if any of the modules we are using in our prepack script rely on install scripts running, but I don't think they do, so I think this is safe to do. Hopefully this will unblock us from running the release workflow for now. We will probably need this change for releasing other packages which have better-sqlite3 as a dep.