### PR TITLE
fix: correct blob & icon urls

### DIFF
--- a/src/hooks/projects.ts
+++ b/src/hooks/projects.ts
@@ -237,9 +237,17 @@ export function useIconUrl({
 } & (IconApi.BitmapOpts | IconApi.SvgOpts)) {
 	const { data: projectApi } = useSingleProject({ projectId })
 
-	const { data: port, error, isRefetching } = useMediaServerPort({ projectApi })
-	const baseUrl = `http://127.0.0.1:${port}`
-	const iconUrl = getIconUrl(baseUrl, iconId, mimeBasedOpts)
+	const {
+		data: serverPort,
+		error,
+		isRefetching,
+	} = useMediaServerPort({ projectApi })
+	const iconUrl = getIconUrl({
+		serverPort,
+		iconId,
+		projectId,
+		mimeBasedOpts,
+	})
 
 	return { data: iconUrl, error, isRefetching }
 }
@@ -304,9 +312,12 @@ export function useAttachmentUrl({
 }) {
 	const { data: projectApi } = useSingleProject({ projectId })
 
-	const { data: port, error, isRefetching } = useMediaServerPort({ projectApi })
-	const baseUrl = `http://127.0.0.1:${port}`
-	const blobUrl = getBlobUrl(baseUrl, blobId)
+	const {
+		data: serverPort,
+		error,
+		isRefetching,
+	} = useMediaServerPort({ projectApi })
+	const blobUrl = getBlobUrl({ serverPort, projectId, blobId })
 
 	return { data: blobUrl, error, isRefetching }
 }
@@ -322,7 +333,7 @@ function useMediaServerPort({ projectApi }: { projectApi: MapeoProjectApi }) {
 		}),
 	)
 
-	return { data, error, isRefetching }
+	return { data: +data, error, isRefetching }
 }
 
 // TODO: Eventually remove in favor of this information being provided by the backend when retrieving documents

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -11,46 +11,46 @@ const MIME_TO_EXTENSION = {
 /**
  * Get a url for a blob based on its BlobId
  */
-export function getBlobUrl(baseUrl: string, blobId: BlobApi.BlobId) {
+export function getBlobUrl({
+	serverPort,
+	projectId,
+	blobId,
+}: {
+	serverPort: number
+	projectId: string
+	blobId: BlobApi.BlobId
+}) {
 	const { driveId, type, variant, name } = blobId
 
-	if (!baseUrl.endsWith('/')) {
-		baseUrl += '/'
-	}
-
-	return baseUrl + `${driveId}/${type}/${variant}/${name}`
+	return `http://localhost:${serverPort}/blobs/${projectId}/${driveId}/${type}/${variant}/${name}`
 }
 
-/**
- * @param {string} iconId
- * @param {BitmapOpts | SvgOpts} opts
- *
- * @returns {Promise<string>}
- */
-export function getIconUrl(
-	baseUrl: string,
-	iconId: string,
-	opts: IconApi.BitmapOpts | IconApi.SvgOpts,
-) {
-	if (!baseUrl.endsWith('/')) {
-		baseUrl += '/'
-	}
-
-	const mimeExtension = MIME_TO_EXTENSION[opts.mimeType]
+export function getIconUrl({
+	serverPort,
+	iconId,
+	projectId,
+	mimeBasedOpts,
+}: {
+	serverPort: number
+	iconId: string
+	projectId: string
+	mimeBasedOpts: IconApi.BitmapOpts | IconApi.SvgOpts
+}) {
+	const mimeExtension = MIME_TO_EXTENSION[mimeBasedOpts.mimeType]
 
 	const pixelDensity =
-		opts.mimeType === 'image/svg+xml' ||
+		mimeBasedOpts.mimeType === 'image/svg+xml' ||
 		// if the pixel density is 1, we can omit the density suffix in the resulting url
 		// and assume the pixel density is 1 for applicable mime types when using the url
-		opts.pixelDensity === 1
+		mimeBasedOpts.pixelDensity === 1
 			? undefined
-			: opts.pixelDensity
+			: mimeBasedOpts.pixelDensity
 
 	return (
-		baseUrl +
+		`http://localhost:${serverPort}/icons/${projectId}/` +
 		constructIconPath({
 			pixelDensity,
-			size: opts.size,
+			size: mimeBasedOpts.size,
 			extension: mimeExtension,
 			iconId,
 		})


### PR DESCRIPTION
I messed up and got confused with how core was constructing URLs. This re-enforces that this is not the best place to have this logic, because it's hard to test against the actual server, but I think it's ok for now.