### PR TITLE
chore: correct TS for mutations without extra code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
 			"name": "@comapeo/core-react",
 			"version": "6.1.1",
 			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^4.41.0"
+			},
 			"devDependencies": {
 				"@comapeo/core": "4.1.3",
 				"@comapeo/ipc": "5.0.0",
@@ -10280,7 +10283,6 @@
 			"version": "4.41.0",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
 			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
 			"engines": {
 				"node": ">=16"

--- a/package.json
+++ b/package.json
@@ -96,5 +96,8 @@
 		"typescript": "5.8.3",
 		"typescript-eslint": "8.34.1",
 		"vitest": "3.2.3"
+	},
+	"dependencies": {
+		"type-fest": "^4.41.0"
 	}
 }

--- a/src/hooks/client.ts
+++ b/src/hooks/client.ts
@@ -7,6 +7,8 @@ import {
 import { useContext } from 'react'
 
 import { ClientApiContext } from '../contexts/ClientApi.js'
+import { EXPOSED_MUTATION_PROPS } from '../lib/constants.js'
+import { pick } from '../lib/pick.js'
 import {
 	deviceInfoQueryOptions,
 	isArchiveDeviceQueryOptions,
@@ -114,11 +116,8 @@ export function useSetIsArchiveDevice() {
 	const queryClient = useQueryClient()
 	const clientApi = useClientApi()
 
-	const { error, mutate, mutateAsync, status, reset } = useMutation(
-		setIsArchiveDeviceMutationOptions({ clientApi, queryClient }),
+	return pick(
+		useMutation(setIsArchiveDeviceMutationOptions({ clientApi, queryClient })),
+		EXPOSED_MUTATION_PROPS,
 	)
-
-	return status === 'error'
-		? { error, mutate, mutateAsync, reset, status }
-		: { error: null, mutate, mutateAsync, reset, status }
 }

--- a/src/hooks/projects.ts
+++ b/src/hooks/projects.ts
@@ -10,6 +10,8 @@ import {
 } from '@tanstack/react-query'
 import { useSyncExternalStore } from 'react'
 
+import { EXPOSED_MUTATION_PROPS } from '../lib/constants.js'
+import { pick } from '../lib/pick.js'
 import {
 	addServerPeerMutationOptions,
 	connectSyncServersMutationOptions,
@@ -398,13 +400,12 @@ export function useAddServerPeer({ projectId }: { projectId: string }) {
 	const queryClient = useQueryClient()
 	const { data: projectApi } = useSingleProject({ projectId })
 
-	const { error, mutate, mutateAsync, reset, status } = useMutation(
-		addServerPeerMutationOptions({ projectApi, projectId, queryClient }),
+	return pick(
+		useMutation(
+			addServerPeerMutationOptions({ projectApi, projectId, queryClient }),
+		),
+		EXPOSED_MUTATION_PROPS,
 	)
-
-	return status === 'error'
-		? { error, mutate, mutateAsync, reset, status }
-		: { error: null, mutate, mutateAsync, reset, status }
 }
 
 export function useRemoveServerPeer({ projectId }: { projectId: string }) {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,7 @@
+export const EXPOSED_MUTATION_PROPS = [
+	'error',
+	'mutate',
+	'mutateAsync',
+	'reset',
+	'status',
+] as const

--- a/src/lib/pick.ts
+++ b/src/lib/pick.ts
@@ -1,0 +1,28 @@
+// Vendored from https://github.com/sindresorhus/filter-obj/blob/7bcfe43cb7bfa8fd553110e0a04043e73f5e78f9/index.js
+// With distributive pick support from https://github.com/sindresorhus/filter-obj/pull/39
+
+import type { Simplify } from 'type-fest'
+
+type DistributivePick<Value, Key extends keyof Value> = Value extends unknown
+	? Pick<Value, Key>
+	: never
+
+export function pick<
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	ObjectType extends Record<PropertyKey, any>,
+	IncludedKeys extends keyof ObjectType,
+>(
+	object: ObjectType,
+	// eslint-disable-next-line @typescript-eslint/array-type
+	keys: readonly IncludedKeys[],
+): Simplify<DistributivePick<ObjectType, IncludedKeys>> {
+	const result = {} as DistributivePick<ObjectType, IncludedKeys>
+	for (const key of keys) {
+		const descriptor = Object.getOwnPropertyDescriptor(object, key)
+		if (!descriptor?.enumerable) {
+			continue
+		}
+		Object.defineProperty(result, key, descriptor)
+	}
+	return result
+}


### PR DESCRIPTION
The mutation hooks currently do this:

```js
	return status === 'error'
		? { error, mutate, reset, status }
		: { error: null, mutate, reset, status }
```

To force typescript into returning the correct distributive type.

This is a follow-up to [this comment](https://github.com/digidem/comapeo-core-react/pull/63#discussion_r2014960422) about better ways to do this.

This is one solution, implementing a `pick` function (similar to what the current object spread and object create is doing) that correctly maintains the types. Adds `Simplify` from `type-fest` so that the return types are more readable for the library consumer.

Leaving this here as an idea, not fully implemented, feel free to ignore or finish the implementation.