### PR TITLE
feat: add prefetch queries for projects and device info

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		}
 	},
 	"scripts": {
-		"docs:generate": "tsdoc --src=src/contexts/*,src/hooks/*,src/lib/types.ts --dest=docs/API.md --noemoji --types",
+		"docs:generate": "tsdoc --src=src/contexts/*,src/hooks/*,src/lib/types.ts,src/lib/react-query/prefetch.ts --dest=docs/API.md --noemoji --types",
 		"lint:eslint": "eslint --cache .",
 		"lint:format": "prettier --cache --check .",
 		"lint": "npm-run-all --parallel --continue-on-error --print-label --aggregate-output lint:*",

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,3 +57,11 @@ export {
 	type WriteableDocumentType,
 	type WriteableValue,
 } from './lib/types.js'
+export {
+	prefetchProjects,
+	prefetchProjectApi,
+	prefetchProjectSettings,
+	prefetchOwnRoleInProject,
+	prefetchMembers,
+	prefetchIsArchiveDevice,
+} from './lib/react-query/prefetch.js'

--- a/src/lib/react-query/prefetch.ts
+++ b/src/lib/react-query/prefetch.ts
@@ -1,0 +1,164 @@
+import type { MapeoClientApi, MapeoProjectApi } from '@comapeo/ipc'
+import type { QueryClient } from '@tanstack/react-query'
+
+import { isArchiveDeviceQueryOptions } from './client.js'
+import {
+	projectByIdQueryOptions,
+	projectMembersQueryOptions,
+	projectOwnRoleQueryOptions,
+	projectSettingsQueryOptions,
+	projectsQueryOptions,
+} from './projects.js'
+
+/**
+ * Prefetch project list into the React Query cache.
+ *
+ * @param queryClient React Query client instance
+ * @param clientApi CoMapeo Client API instance
+ *
+ * @example
+ * ```tsx
+ *
+ * function MenuScreen() {
+ *   const queryClient = useQueryClient()
+ *   const clientApi = useClientApi()
+ *
+ *   useFocusEffect(
+ *     React.useCallback(() => {
+ *       prefetchProjects(queryClient, clientApi)
+ *     }, [queryClient, clientApi])
+ *   )
+ *
+ *   return <UI />
+ * }
+ * ```
+ */
+export async function prefetchProjects(
+	queryClient: QueryClient,
+	clientApi: MapeoClientApi,
+): Promise<void> {
+	const opts = projectsQueryOptions({ clientApi })
+	await queryClient.prefetchQuery({ ...opts, staleTime: Infinity })
+}
+
+/**
+ * Ensure the project API instance is cached and available.
+ *
+ * Returns the project API handle if available.
+ *
+ * @param queryClient React Query client instance
+ * @param clientApi CoMapeo Client API instance
+ * @param projectId Project public ID
+ *
+ * @example
+ * ```tsx
+ * const projectApi = await prefetchProjectApi(queryClient, clientApi, projectId)
+ * if (!projectApi) {
+ *   // Project not found or failed to load; handle gracefully
+ * }
+ * ```
+ */
+export async function prefetchProjectApi(
+	queryClient: QueryClient,
+	clientApi: MapeoClientApi,
+	projectId: string,
+): Promise<MapeoProjectApi | undefined> {
+	try {
+		const opts = projectByIdQueryOptions({ clientApi, projectId })
+		const api = await queryClient.ensureQueryData({
+			...opts,
+			staleTime: Infinity,
+		})
+		return api
+	} catch {
+		return undefined
+	}
+}
+
+/**
+ * Prefetch project settings for a project.
+ *
+ * @param queryClient React Query client instance
+ * @param clientApi CoMapeo Client API instance
+ * @param projectId Project public ID
+ *
+ * @example
+ * ```tsx
+ * await prefetchProjectSettings(queryClient, clientApi, projectId)
+ * ```
+ */
+export async function prefetchProjectSettings(
+	queryClient: QueryClient,
+	clientApi: MapeoClientApi,
+	projectId: string,
+): Promise<void> {
+	const projectApi = await prefetchProjectApi(queryClient, clientApi, projectId)
+	if (!projectApi) return
+	const opts = projectSettingsQueryOptions({ projectApi, projectId })
+	await queryClient.prefetchQuery({ ...opts, staleTime: Infinity })
+}
+
+/**
+ * Prefetch the current device's role in a project.
+ *
+ * @param queryClient React Query client instance
+ * @param clientApi CoMapeo Client API instance
+ * @param projectId Project public ID
+ *
+ * @example
+ * ```tsx
+ * await prefetchOwnRoleInProject(queryClient, clientApi, projectId)
+ * ```
+ */
+export async function prefetchOwnRoleInProject(
+	queryClient: QueryClient,
+	clientApi: MapeoClientApi,
+	projectId: string,
+): Promise<void> {
+	const projectApi = await prefetchProjectApi(queryClient, clientApi, projectId)
+	if (!projectApi) return
+	const opts = projectOwnRoleQueryOptions({ projectApi, projectId })
+	await queryClient.prefetchQuery({ ...opts, staleTime: Infinity })
+}
+
+/**
+ * Prefetch all members for a project.
+ *
+ * @param queryClient React Query client instance
+ * @param clientApi CoMapeo Client API instance
+ * @param projectId Project public ID
+ *
+ * @example
+ * ```tsx
+ * await prefetchMembers(queryClient, clientApi, projectId)
+ * ```
+ */
+export async function prefetchMembers(
+	queryClient: QueryClient,
+	clientApi: MapeoClientApi,
+	projectId: string,
+): Promise<void> {
+	const projectApi = await prefetchProjectApi(queryClient, clientApi, projectId)
+	if (!projectApi) return
+	const opts = projectMembersQueryOptions({ projectApi, projectId })
+	await queryClient.prefetchQuery({ ...opts, staleTime: Infinity })
+}
+
+/**
+ * Prefetch whether the current device is an archive device.
+ *
+ * @param queryClient React Query client instance
+ * @param clientApi CoMapeo Client API instance
+ *
+ * @example
+ * ```tsx
+ * await prefetchIsArchiveDevice(queryClient, clientApi)
+ * ```
+ */
+export async function prefetchIsArchiveDevice(
+	queryClient: QueryClient,
+	clientApi: MapeoClientApi,
+): Promise<void> {
+	const opts = isArchiveDeviceQueryOptions({ clientApi })
+	await queryClient.prefetchQuery({ ...opts, staleTime: Infinity })
+}


### PR DESCRIPTION
towards [#1345](https://github.com/digidem/comapeo-mobile/issues/1345)
There are some long wait times in the mobile app, in particular for the All Projects screen and the Exchange Screen.

- Rather than right something hacky in mobile, it was suggested that we expose some prefetchQueries so that loading certain screens won't take as long.

- So this PR adds one file with some prefetch helpers for the needed calls.

- These are then exported so they can be used on focus in mobile.

- I also did my best to make sure the api docs would work and would look similar to what already exists in here.

- These helpers are not hooks and perform no subscription/side-effects beyond priming cache. It's all an addition so should not change anything (except the api docs) that already exists.

Questions:
1. `staleTime` configurability
Right now it’s hard-coded to Infinity to guarantee zero re-fetch during the menu focus window.
Would you prefer we accept an optional staleTime argument (defaulting to Infinity) so mobile can send it in

2. Tests
Since nothing is returned I wasn't sure what/ how to test but I am open to suggestions!

3. Placement / naming
Kept these as small “lib/react-query” utilities and re-exported from the index. If you want them grouped differently, I can adjust. Just let me know.



