### PR TITLE
chore: hook to change member role

### DIFF
--- a/src/hooks/projects.ts
+++ b/src/hooks/projects.ts
@@ -12,6 +12,7 @@ import { useSyncExternalStore } from 'react'
 
 import {
 	addServerPeerMutationOptions,
+	changeMemberRoleMutationOptions,
 	connectSyncServersMutationOptions,
 	createBlobMutationOptions,
 	createProjectMutationOptions,
@@ -481,6 +482,33 @@ export function useUpdateProjectSettings({ projectId }: { projectId: string }) {
 
 	const { error, mutate, mutateAsync, reset, status } = useMutation(
 		updateProjectSettingsMutationOptions({ projectApi, queryClient }),
+	)
+
+	return status === 'error'
+		? { error, mutate, mutateAsync, reset, status }
+		: { error: null, mutate, mutateAsync, reset, status }
+}
+
+/**
+ * Change a project member's role.
+ *
+ * @param opts.projectId Project public ID
+ *
+ * @example
+ * ```tsx
+ * function BasicExample() {
+ *   const { mutate } = useChangeMemberRole({ projectId: '...' })
+ *   // Use one of: COORDINATOR_ROLE_ID, MEMBER_ROLE_ID, BLOCKED_ROLE_ID
+ *   mutate({ deviceId: '...', roleId: COORDINATOR_ROLE_ID })
+ * }
+ * ```
+ */
+export function useChangeMemberRole({ projectId }: { projectId: string }) {
+	const queryClient = useQueryClient()
+	const { data: projectApi } = useSingleProject({ projectId })
+
+	const { error, mutate, mutateAsync, reset, status } = useMutation(
+		changeMemberRoleMutationOptions({ projectApi, projectId, queryClient }),
 	)
 
 	return status === 'error'

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ export {
 	useStopSync,
 	useSyncState,
 	useUpdateProjectSettings,
+	useChangeMemberRole,
 	useExportGeoJSON,
 	useExportZipFile,
 } from './hooks/projects.js'

--- a/src/lib/react-query/projects.ts
+++ b/src/lib/react-query/projects.ts
@@ -1,6 +1,7 @@
 import type {
 	BlobApi,
 	EditableProjectSettings,
+	MemberApi,
 } from '@comapeo/core' with { 'resolution-mode': 'import' }
 import type {
 	MapeoClientApi,
@@ -391,6 +392,44 @@ export function updateProjectSettingsMutationOptions({
 			projectColor?: ProjectSettings['projectColor']
 			projectDescription?: ProjectSettings['projectDescription']
 		}
+	>
+}
+
+export function changeMemberRoleMutationOptions({
+	projectApi,
+	projectId,
+	queryClient,
+}: {
+	projectApi: MapeoProjectApi
+	projectId: string
+	queryClient: QueryClient
+}) {
+	return {
+		...baseMutationOptions(),
+		mutationFn: async ({
+			deviceId,
+			roleId,
+		}: {
+			deviceId: string
+			roleId: MemberApi.RoleIdForNewInvite
+		}) => {
+			return projectApi.$member.assignRole(deviceId, roleId)
+		},
+		onSuccess: (_data, { deviceId }) => {
+			queryClient.invalidateQueries({
+				queryKey: getMembersQueryKey({ projectId }),
+			})
+			queryClient.invalidateQueries({
+				queryKey: getMemberByIdQueryKey({ projectId, deviceId }),
+			})
+			queryClient.invalidateQueries({
+				queryKey: getProjectRoleQueryKey({ projectId }),
+			})
+		},
+	} satisfies UseMutationOptions<
+		void,
+		Error,
+		{ deviceId: string; roleId: MemberApi.RoleIdForNewInvite }
 	>
 }
 


### PR DESCRIPTION
closes #90 
Adds a hook for changing a members role in a project.
I tried to mirror the existing hook patterns.
I did not add a test because it seemed like there aren't many and not for things of this type.
I wasn't sure what types to use but the RoleIdForNewInvite is the same roles as the ones required by this mutation but that exact type isn't exported as far as I can tell.
