### PR TITLE
Revert "Release v6.2.0 (#108)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@comapeo/core-react",
-	"version": "6.2.0",
+	"version": "6.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@comapeo/core-react",
-			"version": "6.2.0",
+			"version": "6.1.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@comapeo/core": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@comapeo/core-react",
-	"version": "6.2.0",
+	"version": "6.1.1",
 	"description": "React wrapper for working with @comapeo/core",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
This reverts commit d3d3b6edcf9c24d931d727fe1b17f6244e9380a1.

The tagging and publishing of the release failed due to [type issues that surface in the `prepack` step](https://github.com/digidem/comapeo-core-react/actions/runs/17587542167). Should be safe to just revert this and try again when ready.

Separately, should probably include a CI check to make sure that the `tshy` command works, instead of discovering this when trying to publish 😅 