### PR TITLE
Revert "Release v6.2.1 (#116)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@comapeo/core-react",
-	"version": "6.2.1",
+	"version": "6.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@comapeo/core-react",
-			"version": "6.2.1",
+			"version": "6.2.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@comapeo/core": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@comapeo/core-react",
-	"version": "6.2.1",
+	"version": "6.2.0",
 	"description": "React wrapper for working with @comapeo/core",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Attempt to release failed (see https://github.com/digidem/comapeo-core-react/actions/runs/17840173969/job/50727388338).

This reverts commit 0230c5eb32485abee8812c86fb8e1b6d861c8b25.