### PR TITLE
chore: fix auth error in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: nearform-actions/optic-release-automation-action@a2785548e8bdafab7e628c2317b604278e460434 # v4.12.2
         with:


### PR DESCRIPTION
Looks like we missed a permission that's necessary for publishing via OIDC. Suspecting that it's the reason that the release for 6.2.1 failed (see [action run](https://github.com/digidem/comapeo-core-react/actions/runs/17840173969/job/50727388338))