### PR TITLE
fix: loosen input type for updateProjectSettings write hook

### DIFF
--- a/src/lib/react-query/projects.ts
+++ b/src/lib/react-query/projects.ts
@@ -384,7 +384,7 @@ export function updateProjectSettingsMutationOptions({
 	} satisfies UseMutationOptions<
 		EditableProjectSettings,
 		Error,
-		EditableProjectSettings
+		Partial<EditableProjectSettings>
 	>
 }
 


### PR DESCRIPTION
Found the answer to question in #115 (which was my own question but written by Cindy 😄 ). Core allows a `Partial` of that type so we need to align it to avoid type errors related to not specifying required fields for the type as-is.