### PR TITLE
feat: add support for additional derived document fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "6.2.2",
 			"license": "MIT",
 			"devDependencies": {
-				"@comapeo/core": "4.3.0",
+				"@comapeo/core": "4.4.0",
 				"@comapeo/ipc": "5.0.0",
 				"@comapeo/schema": "2.1.1",
 				"@eslint/compat": "1.3.2",
@@ -44,7 +44,7 @@
 				"vitest": "3.2.4"
 			},
 			"peerDependencies": {
-				"@comapeo/core": "^4.3.0",
+				"@comapeo/core": "^4.4.0",
 				"@comapeo/ipc": "^5.0.0",
 				"@comapeo/schema": "*",
 				"@tanstack/react-query": "^5",
@@ -188,14 +188,14 @@
 			}
 		},
 		"node_modules/@comapeo/core": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@comapeo/core/-/core-4.3.0.tgz",
-			"integrity": "sha512-fVdUNLhscIuU8XfV6zxC+6A8U1o7mlosN//bSB/O52Oangn9U5MCoPCwwJDNhs0Y9p3eYWyC4eLHodwKdif7VA==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@comapeo/core/-/core-4.4.0.tgz",
+			"integrity": "sha512-JsB6P17rCjHa8IAu86Xfrkwbi3Cge1PXENJz1XghnKAh4xJAbmVpGw7QpH7zB+VO0ccfgcaTkxGt/fR4vVN3sQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@comapeo/fallback-smp": "^1.0.0",
-				"@comapeo/schema": "^2.1.1",
+				"@comapeo/schema": "2.1.1",
 				"@digidem/types": "^2.3.0",
 				"@fastify/error": "^3.4.1",
 				"@fastify/type-provider-typebox": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -57,14 +57,14 @@
 		"types": "tsc"
 	},
 	"peerDependencies": {
-		"@comapeo/core": "^4.3.0",
+		"@comapeo/core": "^4.4.0",
 		"@comapeo/ipc": "^5.0.0",
 		"@comapeo/schema": "*",
 		"@tanstack/react-query": "^5",
 		"react": "^18 || ^19"
 	},
 	"devDependencies": {
-		"@comapeo/core": "4.3.0",
+		"@comapeo/core": "4.4.0",
 		"@comapeo/ipc": "5.0.0",
 		"@comapeo/schema": "2.1.1",
 		"@eslint/compat": "1.3.2",

--- a/src/hooks/documents.ts
+++ b/src/hooks/documents.ts
@@ -1,4 +1,3 @@
-import type { MapeoDoc } from '@comapeo/schema' with { 'resolution-mode': 'import' }
 import {
 	useMutation,
 	useQueryClient,
@@ -15,12 +14,6 @@ import {
 } from '../lib/react-query/documents.js'
 import type { WriteableDocumentType } from '../lib/types.js'
 import { useSingleProject } from './projects.js'
-
-type ReadHookResult<D> = {
-	data: D
-	error: Error | null
-	isRefetching: boolean
-}
 
 /**
  * Retrieve a single document from the database based on the document's document ID.
@@ -55,7 +48,7 @@ export function useSingleDocByDocId<D extends WriteableDocumentType>({
 	docType: D
 	docId: string
 	lang?: string
-}): ReadHookResult<Extract<MapeoDoc, { schemaName: D }>> {
+}) {
 	const { data: projectApi } = useSingleProject({ projectId })
 
 	const { data, error, isRefetching } = useSuspenseQuery(
@@ -69,10 +62,7 @@ export function useSingleDocByDocId<D extends WriteableDocumentType>({
 	)
 
 	return {
-		// @ts-expect-error - TS does not handle dependent types, so this will not
-		// be narrowed properly within the function body. See for example
-		// https://github.com/microsoft/TypeScript/issues/33014#event-15134418011
-		data,
+		data: data as Extract<typeof data, { schemaName: D }>,
 		error,
 		isRefetching,
 	}
@@ -111,7 +101,7 @@ export function useSingleDocByVersionId<D extends WriteableDocumentType>({
 	docType: D
 	versionId: string
 	lang?: string
-}): ReadHookResult<Extract<MapeoDoc, { schemaName: D }>> {
+}) {
 	const { data: projectApi } = useSingleProject({ projectId })
 
 	const { data, error, isRefetching } = useSuspenseQuery(
@@ -125,8 +115,7 @@ export function useSingleDocByVersionId<D extends WriteableDocumentType>({
 	)
 
 	return {
-		// @ts-expect-error - TS does not handle dependent types, see above
-		data,
+		data: data as Extract<typeof data, { schemaName: D }>,
 		error,
 		isRefetching,
 	}
@@ -176,7 +165,7 @@ export function useManyDocs<D extends WriteableDocumentType>({
 	docType: D
 	includeDeleted?: boolean
 	lang?: string
-}): ReadHookResult<Array<Extract<MapeoDoc, { schemaName: D }>>> {
+}) {
 	const { data: projectApi } = useSingleProject({ projectId })
 
 	const { data, error, isRefetching } = useSuspenseQuery(
@@ -190,8 +179,7 @@ export function useManyDocs<D extends WriteableDocumentType>({
 	)
 
 	return {
-		// @ts-expect-error - TS does not handle dependent types, see above
-		data,
+		data: data as Extract<typeof data, { schemaName: D }>,
 		error,
 		isRefetching,
 	}

--- a/src/hooks/documents.ts
+++ b/src/hooks/documents.ts
@@ -179,7 +179,7 @@ export function useManyDocs<D extends WriteableDocumentType>({
 	)
 
 	return {
-		data: data as Extract<typeof data, { schemaName: D }>,
+		data: data as Extract<typeof data, Array<{ schemaName: D }>>,
 		error,
 		isRefetching,
 	}

--- a/src/lib/react-query/documents.ts
+++ b/src/lib/react-query/documents.ts
@@ -1,3 +1,4 @@
+import type { DerivedDocFields } from '@comapeo/core/dist/datatype/index.js' with { 'resolution-mode': 'import' }
 import type { MapeoProjectApi } from '@comapeo/ipc' with { 'resolution-mode': 'import' }
 import {
 	queryOptions,
@@ -182,7 +183,10 @@ export function documentByVersionIdQueryOptions<
 	})
 }
 
-export function createDocumentMutationOptions<D extends WriteableDocumentType>({
+export function createDocumentMutationOptions<
+	D extends WriteableDocumentType,
+	Result = WriteableDocument<D> & DerivedDocFields,
+>({
 	docType,
 	projectApi,
 	projectId,
@@ -195,9 +199,7 @@ export function createDocumentMutationOptions<D extends WriteableDocumentType>({
 }) {
 	return {
 		...baseMutationOptions(),
-		mutationFn: async ({
-			value,
-		}): Promise<WriteableDocument<D> & { forks: Array<string> }> => {
+		mutationFn: async ({ value }): Promise<Result> => {
 			// @ts-expect-error TS not handling this well
 			return projectApi[docType].create({
 				...value,
@@ -213,13 +215,16 @@ export function createDocumentMutationOptions<D extends WriteableDocumentType>({
 			})
 		},
 	} satisfies UseMutationOptions<
-		WriteableDocument<D> & { forks: Array<string> },
+		Result,
 		Error,
 		{ value: Omit<WriteableValue<D>, 'schemaName'> }
 	>
 }
 
-export function updateDocumentMutationOptions<D extends WriteableDocumentType>({
+export function updateDocumentMutationOptions<
+	D extends WriteableDocumentType,
+	Result = WriteableDocument<D> & DerivedDocFields,
+>({
 	docType,
 	projectApi,
 	projectId,
@@ -232,10 +237,7 @@ export function updateDocumentMutationOptions<D extends WriteableDocumentType>({
 }) {
 	return {
 		...baseMutationOptions(),
-		mutationFn: async ({
-			versionId,
-			value,
-		}): Promise<WriteableDocument<D> & { forks: Array<string> }> => {
+		mutationFn: async ({ versionId, value }): Promise<Result> => {
 			// @ts-expect-error TS not handling this well
 			return projectApi[docType].update(versionId, value)
 		},
@@ -248,13 +250,16 @@ export function updateDocumentMutationOptions<D extends WriteableDocumentType>({
 			})
 		},
 	} satisfies UseMutationOptions<
-		WriteableDocument<D> & { forks: Array<string> },
+		Result,
 		Error,
 		{ versionId: string; value: Omit<WriteableValue<D>, 'schemaName'> }
 	>
 }
 
-export function deleteDocumentMutationOptions<D extends WriteableDocumentType>({
+export function deleteDocumentMutationOptions<
+	D extends WriteableDocumentType,
+	Result = WriteableDocument<D> & DerivedDocFields,
+>({
 	docType,
 	projectApi,
 	projectId,
@@ -267,9 +272,7 @@ export function deleteDocumentMutationOptions<D extends WriteableDocumentType>({
 }) {
 	return {
 		...baseMutationOptions(),
-		mutationFn: async ({
-			docId,
-		}): Promise<WriteableDocument<D> & { forks: Array<string> }> => {
+		mutationFn: async ({ docId }): Promise<Result> => {
 			// @ts-expect-error TS not handling this well
 			return projectApi[docType].delete(docId)
 		},
@@ -281,9 +284,5 @@ export function deleteDocumentMutationOptions<D extends WriteableDocumentType>({
 				}),
 			})
 		},
-	} satisfies UseMutationOptions<
-		WriteableDocument<D> & { forks: Array<string> },
-		Error,
-		{ docId: string }
-	>
+	} satisfies UseMutationOptions<Result, Error, { docId: string }>
 }


### PR DESCRIPTION
`@comapeo/core@4.4.0` introduced the `createdBy` and `updatedBy` fields for data types, which are derived. Without this PR, using the hooks would not expose these fields (in the types) since we're specifying a narrower type annotation that's purely based on the document types defined by schema (i.e. not accounting for derived fields implemented via core).

Ideally we'd make more use of type inference from core for the document-related write hooks, but it results in some kind of ambiguity that prevents TS from resolving the inferred types confidently when trying to build e.g. 

```console
The inferred type of 'useDeleteDocument' cannot be named without a reference to '../../node_modules/rpc-reflector/dist/lib/types.js'. This is likely not portable. A type annotation is necessary.
```

Without being able to infer the types, we'll occasionally run into issues where core may expose some new fields that aren't seemingly available when accessing via core-react (from a types perspective, still available at runtime). Also, this limitation means that we must enforce using the recently released version of core.