### PR TITLE
chore: deprecate useDocumentCreatedBy hook

### DIFF
--- a/src/hooks/projects.ts
+++ b/src/hooks/projects.ts
@@ -353,6 +353,8 @@ function useMediaServerOrigin({ projectApi }: { projectApi: MapeoProjectApi }) {
  *   })
  * }
  * ```
+ *
+ * @deprecated Use `createdBy` field from document read hooks.
  */
 export function useDocumentCreatedBy({
 	projectId,


### PR DESCRIPTION
Since #125 has been released, there's no longer a need for the `useDocumentCreatedBy` read hook. Adds a deprecation notice for now. We'll eventually remove this entirely when our consuming applications have been updated appropriately.