### PR TITLE
chore: adjust release workflow for merged PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   release:
-    if: ${{github.event_name != 'pull_request' || github.event.pull_request.merged}}
+    if: ${{github.event_name != 'pull_request' || (github.event.pull_request.merged && github.event.pull_request.user.login == 'optic-release-automation[bot]')}}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Updates the behavior such that when PRs are merged, only relevant release ones trigger the release action.