### PR TITLE
feat: adds callback support for role change listener

### DIFF
--- a/src/hooks/projects.ts
+++ b/src/hooks/projects.ts
@@ -620,7 +620,7 @@ export function useProjectOwnRoleChangeListener({
 	const { data: projectApi } = useSingleProject({ projectId })
 
 	useEffect(() => {
-		function onRoleChange() {
+		function invalidateCache() {
 			queryClient.invalidateQueries({
 				queryKey: getMembersQueryKey({ projectId }),
 			})
@@ -629,10 +629,10 @@ export function useProjectOwnRoleChangeListener({
 			})
 		}
 
-		projectApi.addListener('own-role-change', onRoleChange)
+		projectApi.addListener('own-role-change', invalidateCache)
 
 		return () => {
-			projectApi.removeListener('own-role-change', onRoleChange)
+			projectApi.removeListener('own-role-change', invalidateCache)
 		}
 	}, [projectApi, queryClient, projectId])
 


### PR DESCRIPTION
**Adds optional callback parameter to project role change listener hook**

- Enables custom handling when a user's role changes in a project

**Motivation**
When a user is removed from a project (role changed to BLOCKED_ROLE_ID), the frontend needs to:

- Navigate the user out of the removed project
- Reset navigation state to a safe screen (Map/Home + bottom sheet)
- Set the active project to the default project 

Currently, the listener only invalidates caches and re-queries data. Without a callback mechanism, there's no reliable way to inject navigation logic and state changes at the exact moment the role change event is received. 

Using a separate useEffect is insufficient because:

- The app might be force-closed before the effect runs
- The timing is less predictable and could lead to race conditions

This change to accept a callback ensures that role change handling happens synchronously and reliably at the application navigator level, before any potential app closure.

