### PR TITLE
feat!: remove useDocumentCreatedBy hook

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -25,7 +25,6 @@
 - [useManyMembers](#usemanymembers)
 - [useIconUrl](#useiconurl)
 - [useAttachmentUrl](#useattachmenturl)
-- [useDocumentCreatedBy](#usedocumentcreatedby)
 - [useOwnRoleInProject](#useownroleinproject)
 - [useAddServerPeer](#useaddserverpeer)
 - [useRemoveServerPeer](#useremoveserverpeer)
@@ -507,32 +506,6 @@ function VideoExample() {
       name: '...',
       driveId: '...',
     }
-  })
-}
-```
-
-
-### useDocumentCreatedBy
-
-Retrieve the device ID that created a document.
-
-| Function | Type |
-| ---------- | ---------- |
-| `useDocumentCreatedBy` | `({ projectId, originalVersionId, }: { projectId: string; originalVersionId: string; }) => { data: string; error: Error or null; isRefetching: boolean; }` |
-
-Parameters:
-
-* `opts.projectId`: Project public ID
-* `opts.originalVersionId`: Version ID of document
-
-
-Examples:
-
-```tsx
-function BasicExample() {
-  const { data } = useDocumentCreatedBy({
-    projectId: '...',
-    originalVersionId: '...',
   })
 }
 ```

--- a/src/hooks/projects.ts
+++ b/src/hooks/projects.ts
@@ -19,7 +19,6 @@ import {
 	baseMutationOptions,
 	baseQueryOptions,
 	filterMutationResult,
-	getDocumentCreatedByQueryKey,
 	getMediaServerOriginQueryKey,
 	getMemberByIdQueryKey,
 	getMembersQueryKey,
@@ -382,50 +381,6 @@ function useMediaServerOrigin({ projectApi }: { projectApi: MapeoProjectApi }) {
 		queryFn: async () => {
 			const url = await projectApi.$blobs.getUrl(FAKE_BLOB_ID)
 			return new URL(url).origin
-		},
-		staleTime: 'static',
-		gcTime: Infinity,
-	})
-
-	return { data, error, isRefetching }
-}
-
-// TODO: Eventually remove in favor of this information being provided by the backend when retrieving documents
-/**
- * Retrieve the device ID that created a document.
- *
- * @param opts.projectId Project public ID
- * @param opts.originalVersionId Version ID of document
- *
- * @example
- * ```tsx
- * function BasicExample() {
- *   const { data } = useDocumentCreatedBy({
- *     projectId: '...',
- *     originalVersionId: '...',
- *   })
- * }
- * ```
- *
- * @deprecated Use `createdBy` field from document read hooks.
- */
-export function useDocumentCreatedBy({
-	projectId,
-	originalVersionId,
-}: {
-	projectId: string
-	originalVersionId: string
-}) {
-	const { data: projectApi } = useSingleProject({ projectId })
-
-	const { data, error, isRefetching } = useSuspenseQuery({
-		...baseQueryOptions(),
-		queryKey: getDocumentCreatedByQueryKey({
-			projectId,
-			originalVersionId,
-		}),
-		queryFn: async () => {
-			return projectApi.$originalVersionIdToDeviceId(originalVersionId)
 		},
 		staleTime: 'static',
 		gcTime: Infinity,

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,6 @@ export {
 	useCreateProject,
 	useDataSyncProgress,
 	useDisconnectSyncServers,
-	useDocumentCreatedBy,
 	useIconUrl,
 	useImportProjectCategories,
 	useImportProjectConfig,

--- a/src/lib/react-query.ts
+++ b/src/lib/react-query.ts
@@ -201,22 +201,6 @@ export function getMemberByIdQueryKey({
 	return [ROOT_QUERY_KEY, 'projects', projectId, 'members', deviceId] as const
 }
 
-export function getDocumentCreatedByQueryKey({
-	projectId,
-	originalVersionId,
-}: {
-	projectId: string
-	originalVersionId: string
-}) {
-	return [
-		ROOT_QUERY_KEY,
-		'projects',
-		projectId,
-		'document_created_by',
-		originalVersionId,
-	] as const
-}
-
 /**
  * We call this within a project hook, because that's the only place the API is
  * exposed right now, but it is the same for all projects, so no need for


### PR DESCRIPTION
Removes the `useDocumentCreatedBy` hook, which was deprecated in favor of using the `createdBy` field on a document.

Desktop is already in a position where this change has no impact. Need to consult with mobile to see if the migration is feasible with minimal work.