### PR TITLE
fix: don't refetch queries of a left project on useLeaveProject success

### DIFF
--- a/src/hooks/projects.ts
+++ b/src/hooks/projects.ts
@@ -565,18 +565,17 @@ export function useLeaveProject() {
 				return clientApi.leaveProject(projectId)
 			},
 			onSuccess: (_data, { projectId }) => {
-				const leftProjectFilter = {
-					queryKey: getProjectByIdQueryKey({ projectId }),
-				}
+				const queryKey = getProjectByIdQueryKey({ projectId })
 				// Leaving closes the project's non-auth data stores, so refetching its
 				// queries would error. Mark them stale without refetching.
 				queryClient.invalidateQueries({
-					...leftProjectFilter,
+					queryKey,
 					refetchType: 'none',
 				})
 				queryClient.invalidateQueries({
 					queryKey: getProjectsQueryKey(),
-					predicate: (query) => !matchQuery(leftProjectFilter, query),
+					// The inverse of above - refetch all projects queries except the one for the left project
+					predicate: (query) => !matchQuery({ queryKey }, query),
 				})
 			},
 		}),

--- a/src/hooks/projects.ts
+++ b/src/hooks/projects.ts
@@ -6,6 +6,7 @@ import type {
 } from '@comapeo/core'
 import type { MapeoClientApi, MapeoProjectApi } from '@comapeo/ipc'
 import {
+	matchQuery,
 	useMutation,
 	UseMutationResult,
 	useQueryClient,
@@ -563,9 +564,19 @@ export function useLeaveProject() {
 			mutationFn: async ({ projectId }: { projectId: string }) => {
 				return clientApi.leaveProject(projectId)
 			},
-			onSuccess: () => {
+			onSuccess: (_data, { projectId }) => {
+				const leftProjectFilter = {
+					queryKey: getProjectByIdQueryKey({ projectId }),
+				}
+				// Leaving closes the project's non-auth data stores, so refetching its
+				// queries would error. Mark them stale without refetching.
+				queryClient.invalidateQueries({
+					...leftProjectFilter,
+					refetchType: 'none',
+				})
 				queryClient.invalidateQueries({
 					queryKey: getProjectsQueryKey(),
+					predicate: (query) => !matchQuery(leftProjectFilter, query),
 				})
 			},
 		}),

--- a/test/hooks/projects.test.tsx
+++ b/test/hooks/projects.test.tsx
@@ -10,9 +10,16 @@ import {
 } from '../../src/hooks/projects.js'
 import {
 	useCreateProject,
+	useLeaveProject,
+	useManyMembers,
+	useManyProjects,
 	useSingleProject,
 	useSyncState,
 } from '../../src/index.js'
+import {
+	getMembersQueryKey,
+	getProjectsQueryKey,
+} from '../../src/lib/react-query.js'
 import { setupCoreIpc } from '../helpers/ipc.js'
 import { createWrapper } from '../helpers/react.js'
 
@@ -180,5 +187,108 @@ describe('sync', () => {
 		// 2. TODO: After project enables sync
 
 		// 3. TODO: After disables sync
+	})
+})
+
+describe('useLeaveProject()', () => {
+	// Regression test: leaving a project closes its non-auth data stores, so
+	// refetching the left project's queries errors with 'Cannot await idle
+	// after closing'. Queries for the left project must not be refetched.
+	test('does not refetch queries for the left project', async (t) => {
+		const { client, cleanup } = setupCoreIpc()
+
+		t.onTestFinished(() => {
+			return cleanup()
+		})
+
+		const queryClient = new QueryClient()
+
+		const wrapper = createWrapper({ clientApi: client, queryClient })
+
+		const projectId = await client.createProject({ name: 'project_1' })
+		const otherProjectId = await client.createProject({ name: 'project_2' })
+
+		// Simulates a screen that stays mounted during the leave flow
+		// (e.g. a project members list)
+		const membersHook = renderHook(
+			() => useManyMembers({ projectId, includeLeft: true }),
+			{ wrapper },
+		)
+
+		// A query for a different project, which should still be refetched
+		const otherMembersHook = renderHook(
+			() => useManyMembers({ projectId: otherProjectId, includeLeft: true }),
+			{ wrapper },
+		)
+
+		await waitFor(() => {
+			assert.isNotNull(membersHook.result.current.data)
+			assert.isNotNull(otherMembersHook.result.current.data)
+		})
+
+		const otherMembersUpdatedAt = queryClient.getQueryState(
+			getMembersQueryKey({ projectId: otherProjectId, includeLeft: true }),
+		)?.dataUpdatedAt
+
+		assert(otherMembersUpdatedAt)
+
+		const projectsListHook = renderHook(() => useManyProjects(), { wrapper })
+
+		await waitFor(() => {
+			assert.isNotNull(projectsListHook.result.current.data)
+		})
+
+		const projectsListUpdatedAt = queryClient.getQueryState(
+			getProjectsQueryKey(),
+		)?.dataUpdatedAt
+
+		assert(projectsListUpdatedAt)
+
+		const leaveHook = renderHook(() => useLeaveProject(), { wrapper })
+
+		act(() => {
+			leaveHook.result.current.mutate({ projectId })
+		})
+
+		await waitFor(() => {
+			assert.strictEqual(leaveHook.result.current.status, 'success')
+		})
+
+		// Wait for invalidation-triggered refetches to settle
+		await waitFor(() => {
+			assert.strictEqual(queryClient.isFetching(), 0)
+		})
+
+		assert.isNull(
+			membersHook.result.current.error,
+			'members query for the left project was not refetched',
+		)
+
+		// The left project's queries should be marked stale, so that they are
+		// refetched if ever observed again (e.g. after re-joining the project)
+		assert.isTrue(
+			queryClient.getQueryState(
+				getMembersQueryKey({ projectId, includeLeft: true }),
+			)?.isInvalidated,
+			'members query for the left project is marked stale',
+		)
+
+		// The projects list itself should still be refreshed
+		await waitFor(() => {
+			const updatedAt = queryClient.getQueryState(
+				getProjectsQueryKey(),
+			)?.dataUpdatedAt
+			assert(updatedAt)
+			assert.isAbove(updatedAt, projectsListUpdatedAt)
+		})
+
+		// Queries for other projects should still be refetched
+		await waitFor(() => {
+			const updatedAt = queryClient.getQueryState(
+				getMembersQueryKey({ projectId: otherProjectId, includeLeft: true }),
+			)?.dataUpdatedAt
+			assert(updatedAt)
+			assert.isAbove(updatedAt, otherMembersUpdatedAt)
+		})
 	})
 })


### PR DESCRIPTION
Fixes #182

## Problem

`useLeaveProject`'s `onSuccess` invalidated the root projects query key. React Query invalidation is prefix-matched, so this refetched **every active project-scoped query — including the left project's**. Leaving a project closes its non-auth data stores in `@comapeo/core`, so those refetches always reject with `Cannot await idle after closing`.

In CoMapeo Mobile this fires on every leave-project action, because screens holding member queries are still mounted when the mutation succeeds. See Sentry [COMAPEO-1TK](https://awana-digital.sentry.io/issues/7072609149/) (186 events / 15 users), plus [COMAPEO-223](https://awana-digital.sentry.io/issues/7434500086/) and [COMAPEO-20E](https://awana-digital.sentry.io/issues/7383452114/) for the `$member.getById(own)` → `MissingOwnDeviceInfoError` variant.

## Fix

On leave success:
- Mark the left project's queries (`getProjectByIdQueryKey`) stale with `refetchType: 'none'` — no refetch now; they refetch only if ever actively observed again.
- Invalidate the rest of the projects tree with a `predicate` excluding the left project's keys, preserving the existing behaviour (e.g. the projects list still refreshes).

## Test

Adds a regression test that mounts `useManyMembers` for a project (simulating a screen that stays mounted during the leave flow, as in mobile), leaves the project, and asserts the members query is not refetched into an error state while the projects list still refreshes.

Verified the test fails without the fix, reproducing the production error exactly:

```
AssertionError: members query for the left project was not refetched:
expected Error: Cannot await idle after closing to equal null
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
