### PR TITLE
fix: narrow return type for useSingleDocByDocId

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -841,7 +841,7 @@ Triggers the closest error boundary if the document cannot be found
 
 | Function | Type |
 | ---------- | ---------- |
-| `useSingleDocByDocId` | `<D extends WriteableDocumentType>({ projectId, docType, docId, lang, }: { projectId: string; docType: D; docId: string; lang?: string or undefined; }) => Pick<UseSuspenseQueryResult<Awaited<ReturnType<ClientApi<MapeoProject>[D]["getByDocId"]>>>, "data" or ... 1 more ... or "isRefetching">` |
+| `useSingleDocByDocId` | `<D extends WriteableDocumentType>({ projectId, docType, docId, lang, }: { projectId: string; docType: D; docId: string; lang?: string or undefined; }) => Pick<UseSuspenseQueryResult<NonNullable<Awaited<ReturnType<ClientApi<MapeoProject>[D]["getByDocId"]>>>>, "data" or ... 1 more ... or "isRefetching">` |
 
 Parameters:
 

--- a/src/hooks/documents.ts
+++ b/src/hooks/documents.ts
@@ -57,7 +57,10 @@ export function useSingleDocByDocId<D extends WriteableDocumentType>({
 	lang?: string
 }): // NOTE: Needs explicit return type due to TS struggles with inference
 Pick<
-	UseSuspenseQueryResult<Awaited<ReturnType<MapeoProjectApi[D]['getByDocId']>>>,
+	UseSuspenseQueryResult<
+		// NOTE: Using NonNullable here to get the return type associated with the overload that uses `mustBeFound: true`
+		NonNullable<Awaited<ReturnType<MapeoProjectApi[D]['getByDocId']>>>
+	>,
 	'data' | 'error' | 'isRefetching'
 > {
 	const { data: projectApi } = useSingleProject({ projectId })


### PR DESCRIPTION
Fixes #185 

Kind of a quick and dirty solution. Ideally we'd put more thought into how we define return types, in addition to adding some types testing. Will consider those for follow up.