### PR TITLE
fix: allow more flexible return type for getMapBaseUrl prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,47 @@ npm install react @tanstack/react-query@5 @comapeo/core-react @comapeo/core @com
 
 Wrap your application with `ComapeoCoreProvider` and a React Query `QueryClientProvider`. You will need to be running an instance of [`@comapeo/map-server`](https://github.com/digidem/comapeo-map-server) and provide a `getMapServerBaseUrl` function that returns a Promise resolving to the base URL of your map server:
 
-```tsx
+In the server:
+
+```ts
 import { ComapeoCoreProvider } from '@comapeo/core-react'
+import {
+	createComapeoCoreServer,
+	createComapeoServicesServer,
+} from '@comapeo/ipc/server.js'
 import { createServer } from '@comapeo/map-server'
+
+const mapServer = createServer()
+const listenPromise = mapServer.listen()
+
+const servicesServer = createComapeoServicesServer(
+	{
+		mapServer: {
+			getBaseUrl: async () => {
+				const { localPort } = await listenPromise()
+				return `http://localhost:${localPort}`
+			},
+		},
+	},
+	port,
+)
+```
+
+In the client:
+
+```tsx
+import {
+	createComapeoCoreClient,
+	createComapeoServicesClient,
+} from '@comapeo/ipc/client.js'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 const queryClient = new QueryClient()
 
-const server = createServer()
-const listenPromise = server.listen()
+const servicesClient = createComapeoServicesClient(port)
 
 const getMapServerBaseUrl = async () => {
-	const { localPort } = await listenPromise
-	return new URL(`http://localhost:${localPort}/`)
+	return new URL(await servicesClient.mapServer.getBaseUrl())
 }
 
 function App() {

--- a/README.md
+++ b/README.md
@@ -55,17 +55,13 @@ const queryClient = new QueryClient()
 
 const servicesClient = createComapeoServicesClient(port)
 
-const getMapServerBaseUrl = async () => {
-	return new URL(await servicesClient.mapServer.getBaseUrl())
-}
-
 function App() {
 	return (
 		<QueryClientProvider client={queryClient}>
 			<ComapeoCoreProvider
 				clientApi={clientApi}
 				queryClient={queryClient}
-				getMapServerBaseUrl={getMapServerBaseUrl}
+				getMapServerBaseUrl={servicesClient.mapServer.getBaseUrl}
 			>
 				<MyApp />
 			</ComapeoCoreProvider>

--- a/docs/API.md
+++ b/docs/API.md
@@ -1462,7 +1462,7 @@ function SentShareStatus({ shareId }: { shareId: string }) {
 
 | Type | Type |
 | ---------- | ---------- |
-| `MapServerApiOptions` | `{ getBaseUrl(): Promise<URL> /** * We assume the passed fetch implementation will only accept a `string` as * input, not a `URL` or `Request`, because right now the expo/fetch * implementation will only accept a `string`. Adding this restriction will * catch potential issues if we try to pass a URL in our code. Can be relaxed * when https://github.com/expo/expo/issues/43193 is fixed upstream. */ fetch?(input: string, options?: RequestInit): Promise<Response> }` |
+| `MapServerApiOptions` | `{ getBaseUrl(): Promise<URL or string> /** * We assume the passed fetch implementation will only accept a `string` as * input, not a `URL` or `Request`, because right now the expo/fetch * implementation will only accept a `string`. Adding this restriction will * catch potential issues if we try to pass a URL in our code. Can be relaxed * when https://github.com/expo/expo/issues/43193 is fixed upstream. */ fetch?(input: string, options?: RequestInit): Promise<Response> }` |
 
 ### MapServerApi
 

--- a/src/contexts/ComapeoCore.ts
+++ b/src/contexts/ComapeoCore.ts
@@ -5,7 +5,7 @@ import { MapServerProvider, type MapServerProviderProps } from './MapServer.js'
 
 type ComapeoCoreProviderProps = ClientApiProviderProps &
 	Omit<MapServerProviderProps, 'getBaseUrl'> & {
-		getMapServerBaseUrl(): Promise<URL>
+		getMapServerBaseUrl(): Promise<URL | string>
 	}
 
 export function ComapeoCoreProvider({

--- a/src/contexts/MapServer.ts
+++ b/src/contexts/MapServer.ts
@@ -22,7 +22,7 @@ import {
 } from './MapShares.js'
 
 export type MapServerApiOptions = {
-	getBaseUrl(): Promise<URL>
+	getBaseUrl(): Promise<URL | string>
 	/**
 	 * We assume the passed fetch implementation will only accept a `string` as
 	 * input, not a `URL` or `Request`, because right now the expo/fetch

--- a/test/helpers/react.tsx
+++ b/test/helpers/react.tsx
@@ -12,7 +12,7 @@ export function createWrapper({
 }: {
 	clientApi?: ComapeoCoreClientApi
 	queryClient?: QueryClient
-	getMapServerBaseUrl?: () => Promise<URL>
+	getMapServerBaseUrl?: () => Promise<URL | string>
 } = {}) {
 	return ({ children }: PropsWithChildren<unknown>) => {
 		return (


### PR DESCRIPTION
Follow-up for #191 to account for changes due to updated usage of `@comapeo/ipc`.