### PR TITLE
fix: stream custom map imports from disk when the file supports it

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1130,6 +1130,9 @@ function ExampleWithoutRefreshToken() {
 
 Import a custom SMP map file, replacing any existing custom map. The mutation
 resolves once the file is successfully uploaded and processed by the server.
+If the file has an `upload` method (e.g. an expo-file-system `File`), it is
+used for the upload so that the file is streamed from disk rather than read
+into memory.
 
 | Function | Type |
 | ---------- | ---------- |
@@ -1448,6 +1451,8 @@ function SentShareStatus({ shareId }: { shareId: string }) {
 ## Types
 
 - [ClientApiProviderProps](#clientapiproviderprops)
+- [CompatFile](#compatfile)
+- [ExpoFileDuckType](#expofileducktype)
 - [MapServerApiOptions](#mapserverapioptions)
 - [MapServerApi](#mapserverapi)
 - [MapServerProviderProps](#mapserverproviderprops)
@@ -1457,6 +1462,18 @@ function SentShareStatus({ shareId }: { shareId: string }) {
 | Type | Type |
 | ---------- | ---------- |
 | `ClientApiProviderProps` | `PropsWithChildren<{ clientApi: ComapeoCoreClientApi }>` |
+
+### CompatFile
+
+| Type | Type |
+| ---------- | ---------- |
+| `CompatFile` | `Omit<File, 'lastModified' or 'webkitRelativePath'>` |
+
+### ExpoFileDuckType
+
+| Type | Type |
+| ---------- | ---------- |
+| `ExpoFileDuckType` | `CompatFile and { exists: boolean }` |
 
 ### MapServerApiOptions
 
@@ -1468,7 +1485,7 @@ function SentShareStatus({ shareId }: { shareId: string }) {
 
 | Type | Type |
 | ---------- | ---------- |
-| `MapServerApi` | `ReturnType<typeof createHttp> and { createEventSource(options: EventSourceOptions): EventSourceClient getMapStyleJsonUrl(mapId: string): Promise<string> }` |
+| `MapServerApi` | `ReturnType<typeof createHttp> and { createEventSource(options: EventSourceOptions): EventSourceClient getMapStyleJsonUrl(mapId: string): Promise<string> uploadFile( path: string, file: CompatFile or ExpoFileDuckType, options?: { headers?: Record<string, string> }, ): Promise<Response> }` |
 
 ### MapServerProviderProps
 

--- a/src/contexts/MapServer.ts
+++ b/src/contexts/MapServer.ts
@@ -15,11 +15,43 @@ import {
 } from 'react'
 
 import { useClientApi } from '../hooks/client.js'
-import { createHttp } from '../lib/http.js'
+import { createHttp, HTTPError } from '../lib/http.js'
 import {
 	ReceivedMapSharesProvider,
 	SentMapSharesProvider,
 } from './MapShares.js'
+
+// Expo's file-system File type is close to the standard File type, so for our
+// import function we accept an object with the compatible properties and
+// methods, and for the expo File, which can represent a file that does not yet
+// exists, we type the `exists` property so that we can check that.
+export type CompatFile = Omit<File, 'lastModified' | 'webkitRelativePath'>
+export type ExpoFileDuckType = CompatFile & {
+	exists: boolean
+}
+
+type ExpoFileUploadResult = {
+	status: number
+	headers: Record<string, string>
+	body: string
+}
+
+type ExpoFileWithUpload = ExpoFileDuckType & {
+	upload(
+		url: string,
+		options?: {
+			headers?: Record<string, string>
+			httpMethod?: string
+			sessionType?: 'background' | 'foreground'
+		},
+	): Promise<ExpoFileUploadResult>
+}
+
+function isExpoFileWithUpload(
+	file: CompatFile | ExpoFileDuckType,
+): file is ExpoFileWithUpload {
+	return 'upload' in file && typeof file.upload === 'function'
+}
 
 export type MapServerApiOptions = {
 	getBaseUrl(): Promise<URL | string>
@@ -36,6 +68,11 @@ export type MapServerApiOptions = {
 export type MapServerApi = ReturnType<typeof createHttp> & {
 	createEventSource(options: EventSourceOptions): EventSourceClient
 	getMapStyleJsonUrl(mapId: string): Promise<string>
+	uploadFile(
+		path: string,
+		file: CompatFile | ExpoFileDuckType,
+		options?: { headers?: Record<string, string> },
+	): Promise<Response>
 }
 
 /**
@@ -70,6 +107,46 @@ export function createMapServerApi({
 		value: async (mapId: string) => {
 			const baseUrl = await getBaseUrl()
 			return new URL(`/maps/${mapId}/style.json`, baseUrl).href
+		},
+	})
+	Object.defineProperty(api, 'uploadFile', {
+		value: async (
+			path: string,
+			file: CompatFile | ExpoFileDuckType,
+			options: { headers?: Record<string, string> } = {},
+		): Promise<Response> => {
+			if (!isExpoFileWithUpload(file)) {
+				return api.put(path, { body: file, headers: options.headers })
+			}
+			// expo-file-system's File.upload() streams the file from disk, unlike
+			// expo/fetch, which reads the whole request body into memory.
+			const baseUrl = await getBaseUrl()
+			const url = new URL(path, baseUrl).href
+			const result = await file.upload(url, {
+				httpMethod: 'PUT',
+				headers: options.headers,
+				// The map server runs in-process: an iOS background session (the
+				// default), which outlives app suspension, cannot reach it.
+				sessionType: 'foreground',
+			})
+			const canHaveBody = ![204, 205, 304].includes(result.status)
+			const response = new Response(canHaveBody ? result.body : null, {
+				status: result.status,
+				headers: result.headers,
+			})
+			if (!response.ok) {
+				let errorBody: Record<string, unknown> = {}
+				try {
+					const parsed: unknown = JSON.parse(result.body)
+					if (typeof parsed === 'object' && parsed !== null) {
+						errorBody = parsed as Record<string, unknown>
+					}
+				} catch {
+					// Non-JSON error body: fall back to the default HTTPError message
+				}
+				throw new HTTPError(response, { method: 'PUT', url, ...errorBody })
+			}
+			return response
 		},
 	})
 	return api as MapServerApi

--- a/src/hooks/maps.ts
+++ b/src/hooks/maps.ts
@@ -9,7 +9,10 @@ import {
 } from '@tanstack/react-query'
 import { useCallback } from 'react'
 
-import { useMapServerApi } from '../contexts/MapServer.js'
+import {
+	useMapServerApi,
+	type ExpoFileDuckType,
+} from '../contexts/MapServer.js'
 import {
 	useReceivedMapSharesActions,
 	useReceivedMapSharesState,
@@ -71,18 +74,12 @@ export function useMapStyleUrl() {
 	return { data, error, isRefetching }
 }
 
-// Expo's file-system File type is close to the standard File type, so for our
-// import function we accept an object with the compatible properties and
-// methods, and for the expo File, which can represent a file that does not yet
-// exists, we type the `exists` property so that we can check that.
-type CompatFile = Omit<File, 'lastModified' | 'webkitRelativePath'>
-type ExpoFileDuckType = CompatFile & {
-	exists: boolean
-}
-
 /**
  * Import a custom SMP map file, replacing any existing custom map. The mutation
  * resolves once the file is successfully uploaded and processed by the server.
+ * If the file has an `upload` method (e.g. an expo-file-system `File`), it is
+ * used for the upload so that the file is streamed from disk rather than read
+ * into memory.
  *
  * @example
  * ```tsx
@@ -106,8 +103,7 @@ export function useImportCustomMapFile() {
 				if ('exists' in file && !file.exists) {
 					throw new Error('File does not exist or is not accessible')
 				}
-				return mapServerApi.put(`maps/${mapId}`, {
-					body: file,
+				return mapServerApi.uploadFile(`maps/${mapId}`, file, {
 					headers: {
 						'Content-Type': 'application/octet-stream',
 					},

--- a/test/hooks/maps.test.tsx
+++ b/test/hooks/maps.test.tsx
@@ -135,6 +135,99 @@ describe('Map Hooks', () => {
 			expect(result.current.styleUrl.data).not.toBe(urlBefore)
 		})
 
+		it('uses the file `upload` method when available (e.g. expo File)', async (t) => {
+			const server = await startMapServer(t, { customMapPath: OSM_BRIGHT_Z6 })
+			const Wrapper = createWrapper({
+				getMapServerBaseUrl: async () => new URL(server.localBaseUrl),
+			})
+
+			const { result } = renderHook(
+				() => ({
+					styleUrl: useMapStyleUrl(),
+					importMap: useImportCustomMapFile(),
+				}),
+				{ wrapper: Wrapper },
+			)
+
+			await waitFor(() => {
+				expect(result.current.styleUrl.data).toBeDefined()
+			})
+
+			const urlBefore = result.current.styleUrl.data
+
+			const buffer = fs.readFileSync(DEMOTILES_Z2)
+			const upload = vi.fn(
+				async (url: string, options?: { headers?: Record<string, string> }) => {
+					const response = await fetch(url, {
+						method: 'PUT',
+						headers: options?.headers,
+						body: buffer,
+					})
+					return {
+						status: response.status,
+						headers: Object.fromEntries(response.headers.entries()),
+						body: await response.text(),
+					}
+				},
+			)
+			const file = Object.assign(
+				readFixtureAsFile(DEMOTILES_Z2, 'demotiles-z2.smp'),
+				{ exists: true, upload },
+			)
+
+			await act(async () => {
+				await result.current.importMap.mutateAsync({ file })
+			})
+
+			expect(upload).toHaveBeenCalledOnce()
+			const [url, options] = upload.mock.calls[0]!
+			expect(new URL(url).pathname).toBe('/maps/custom')
+			expect(options).toMatchObject({
+				httpMethod: 'PUT',
+				headers: { 'Content-Type': 'application/octet-stream' },
+				sessionType: 'foreground',
+			})
+
+			await waitFor(() =>
+				expect(result.current.styleUrl.data).not.toBe(urlBefore),
+			)
+		})
+
+		it('rejects with an HTTPError when the `upload` method returns an error response', async (t) => {
+			const server = await startMapServer(t)
+			const Wrapper = createWrapper({
+				getMapServerBaseUrl: async () => new URL(server.localBaseUrl),
+			})
+
+			const { result } = renderHook(() => useImportCustomMapFile(), {
+				wrapper: Wrapper,
+			})
+
+			const upload = vi.fn(async () => ({
+				status: 400,
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({
+					message: 'Invalid SMP file',
+					code: 'INVALID_MAP_FILE',
+				}),
+			}))
+			const file = Object.assign(
+				readFixtureAsFile(DEMOTILES_Z2, 'demotiles-z2.smp'),
+				{ exists: true, upload },
+			)
+
+			await expect(
+				act(async () => {
+					await result.current.mutateAsync({ file })
+				}),
+			).rejects.toMatchObject({
+				name: 'HTTPError',
+				status: 400,
+				code: 'INVALID_MAP_FILE',
+				message: 'Invalid SMP file',
+			})
+		})
+
 		it('style json content changes after map import', async (t) => {
 			const server = await startMapServer(t, { customMapPath: OSM_BRIGHT_Z6 })
 			const Wrapper = createWrapper({


### PR DESCRIPTION
## Problem

`useImportCustomMapFile()` uploads the map file with `fetch`. On React Native the injected `expo/fetch` implementation reads the whole request body into memory before sending (`normalizeBodyInitAsync` converts any Blob-shaped body, including an expo-file-system `File`, to a `Uint8Array` — still the case in SDK 56). Large SMP files can exhaust memory, which is why comapeo-mobile currently carries a patch to `expo/fetch` adding native file streaming. That patch is Android-only and has to be rebased on every SDK upgrade.

## Solution

expo-file-system's `File.upload()` streams the file from disk on both platforms (OkHttp `RequestBody` streaming from an `InputStream` on Android, `URLSession.uploadTask(fromFile:)` on iOS), so we can use it instead of fetch when it's available.

This adds an `uploadFile` method to the internal map server API which duck-types the file: if it has an `upload` method it is called with the resolved URL (`httpMethod: 'PUT'`, and `sessionType: 'foreground'`, since an iOS background session can't reach the in-process map server across app suspension); otherwise it falls back to the existing fetch `PUT`, so web and electron are unaffected (browser fetch already streams `File` bodies from disk). The mutation keeps its existing contract: it resolves with a `Response` and rejects with an `HTTPError` (error details parsed from a JSON body when available) on non-2xx responses.

With this, comapeo-mobile can drop its `expo/fetch` patch entirely.